### PR TITLE
device,sdcard: improve inline SDHelper coding style 

### DIFF
--- a/src/main/scala/device/AXI4DummySD.scala
+++ b/src/main/scala/device/AXI4DummySD.scala
@@ -54,9 +54,11 @@ class SDHelper extends BlackBox with HasBlackBoxInline {
       |  output reg [31:0] data
       |);
       |
-      |  always@(*) begin
-      |    if (setAddr) sd_setaddr(addr);
+      |  always @(negedge clk) begin
       |    if (ren) sd_read(data);
+      |  end
+      |  always@(posedge clk) begin
+      |    if (setAddr) sd_setaddr(addr);
       |  end
       |
       |endmodule


### PR DESCRIPTION
This pull requests modifies inline SDHelper module in AXI4DummySD.
It uses always@(nededge clk) to support async reading and holding data.
This pull request should fixed compilation errors on Verilator v4.108.