### PR TITLE
fix: fix deprecated warnings

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -12,6 +12,8 @@ trait HasXsource211 extends ScalaModule {
     super.scalacOptions() ++ Seq(
       "-deprecation",
       "-unchecked",
+      "-feature",
+      "-language:reflectiveCalls",
       "-Xsource:2.11"
     )
   }

--- a/src/main/scala/bus/axi4/AXI4.scala
+++ b/src/main/scala/bus/axi4/AXI4.scala
@@ -122,10 +122,10 @@ class AXI4(val dataBits: Int = AXI4Parameters.dataBits, val idBits: Int = AXI4Pa
   override val r  = Flipped(Decoupled(new AXI4BundleR(dataBits, idBits)))
 
   def dump(name: String) = {
-    when (aw.fire()) { printf(p"${GTimer()},[${name}.aw] ${aw.bits}\n") }
-    when (w.fire()) { printf(p"${GTimer()},[${name}.w] ${w.bits}\n") }
-    when (b.fire()) { printf(p"${GTimer()},[${name}.b] ${b.bits}\n") }
-    when (ar.fire()) { printf(p"${GTimer()},[${name}.ar] ${ar.bits}\n") }
-    when (r.fire()) { printf(p"${GTimer()},[${name}.r] ${r.bits}\n") }
+    when (aw.fire) { printf(p"${GTimer()},[${name}.aw] ${aw.bits}\n") }
+    when (w.fire) { printf(p"${GTimer()},[${name}.w] ${w.bits}\n") }
+    when (b.fire) { printf(p"${GTimer()},[${name}.b] ${b.bits}\n") }
+    when (ar.fire) { printf(p"${GTimer()},[${name}.ar] ${ar.bits}\n") }
+    when (r.fire) { printf(p"${GTimer()},[${name}.r] ${r.bits}\n") }
   }
 }

--- a/src/main/scala/bus/simplebus/Crossbar.scala
+++ b/src/main/scala/bus/simplebus/Crossbar.scala
@@ -36,7 +36,7 @@ class SimpleBusCrossbar1toN(addressSpace: List[(Long, Long)]) extends Module {
     range => (addr >= range._1.U && addr < (range._1 + range._2).U)))
   val outSelIdx = PriorityEncoder(outSelVec)
   val outSel = io.out(outSelIdx)
-  val outSelIdxResp = RegEnable(outSelIdx, outSel.req.fire() && (state === s_idle))
+  val outSelIdxResp = RegEnable(outSelIdx, outSel.req.fire && (state === s_idle))
   val outSelResp = io.out(outSelIdxResp)
   val reqInvalidAddr = io.in.req.valid && !outSelVec.asUInt.orR
 
@@ -57,14 +57,14 @@ class SimpleBusCrossbar1toN(addressSpace: List[(Long, Long)]) extends Module {
 
   switch (state) {
     is (s_idle) { 
-      when (outSel.req.fire()) { state := s_resp } 
+      when (outSel.req.fire) { state := s_resp } 
       when (reqInvalidAddr) { state := s_error } 
     }
-    is (s_resp) { when (outSelResp.resp.fire()) { state := s_idle } }
-    is (s_error) { when(io.in.resp.fire()){ state := s_idle } }
+    is (s_resp) { when (outSelResp.resp.fire) { state := s_idle } }
+    is (s_error) { when(io.in.resp.fire){ state := s_idle } }
   }
 
-  io.in.resp.valid := outSelResp.resp.fire() || state === s_error
+  io.in.resp.valid := outSelResp.resp.fire || state === s_error
   io.in.resp.bits <> outSelResp.resp.bits
   // io.in.resp.bits.exc.get := state === s_error
   outSelResp.resp.ready := io.in.resp.ready
@@ -75,14 +75,14 @@ class SimpleBusCrossbar1toN(addressSpace: List[(Long, Long)]) extends Module {
       printf(p"${GTimer()}: xbar: in.req: ${io.in.req.bits}\n")
     }
 
-    when (outSel.req.fire()) {
+    when (outSel.req.fire) {
       printf(p"${GTimer()}: xbar: outSelIdx = ${outSelIdx}, outSel.req: ${outSel.req.bits}\n")
     }
-    when (outSel.resp.fire()) {
+    when (outSel.resp.fire) {
       printf(p"${GTimer()}: xbar: outSelIdx= ${outSelIdx}, outSel.resp: ${outSel.resp.bits}\n")
     }
 
-    when (io.in.resp.fire()) {
+    when (io.in.resp.fire) {
       printf(p"${GTimer()}: xbar: in.resp: ${io.in.resp.bits}\n")
     }
   }
@@ -118,14 +118,14 @@ class SimpleBusCrossbarNto1(n: Int, userBits:Int = 0) extends Module {
 
   switch (state) {
     is (s_idle) {
-      when (thisReq.fire()) {
+      when (thisReq.fire) {
         inflightSrc := inputArb.io.chosen
         when (thisReq.bits.isRead()) { state := s_readResp }
         .elsewhen (thisReq.bits.isWriteLast() || thisReq.bits.isWriteSingle()) { state := s_writeResp }
       }
     }
-    is (s_readResp) { when (io.out.resp.fire() && io.out.resp.bits.isReadLast()) { state := s_idle } }
-    is (s_writeResp) { when (io.out.resp.fire()) { state := s_idle } }
+    is (s_readResp) { when (io.out.resp.fire && io.out.resp.bits.isReadLast()) { state := s_idle } }
+    is (s_writeResp) { when (io.out.resp.fire) { state := s_idle } }
   }
 }
 
@@ -181,10 +181,10 @@ class SimpleBusAutoIDCrossbarNto1(n: Int, userBits: Int = 0) extends Module {
   }
 
   Debug(){
-    when(io.out.req.fire()){
+    when(io.out.req.fire){
       printf("[Crossbar REQ] addr %x cmd %x select %b\n", io.out.req.bits.addr, io.out.req.bits.cmd, reqSelectVec)
     }
-    when(io.out.resp.fire()){
+    when(io.out.resp.fire){
       printf("[Crossbar RESP] data %x select %b\n", io.out.resp.bits.rdata, io.out.resp.bits.id.get)
     }
   }

--- a/src/main/scala/bus/simplebus/DistributedMem.scala
+++ b/src/main/scala/bus/simplebus/DistributedMem.scala
@@ -56,16 +56,16 @@ class DistributedMem(memByte: Int, dualPort: Boolean, delayCycles: Int = 0, data
     val state = RegInit(s_idle)
     switch (state) {
       is (s_idle) {
-        when (p.req.fire()) { state := Mux(p.resp.fire(), s_idle, s_reading) }
+        when (p.req.fire) { state := Mux(p.resp.fire, s_idle, s_reading) }
       }
       is (s_reading) {
-        when (p.resp.fire()) { state := s_idle }
+        when (p.resp.fire) { state := s_idle }
       }
     }
 
     p.req.ready := state === s_idle
     p.resp.bits.rdata := rdata
-    p.resp.valid := (if (delayCycles == 0) p.req.fire() else Counter(state === s_reading, delayCycles)._2)
+    p.resp.valid := (if (delayCycles == 0) p.req.fire else Counter(state === s_reading, delayCycles)._2)
   }
 
   readPort(io.rw, rwData)

--- a/src/main/scala/bus/simplebus/SimpleBus.scala
+++ b/src/main/scala/bus/simplebus/SimpleBus.scala
@@ -107,8 +107,8 @@ class SimpleBusUC(val userBits: Int = 0, val addrBits: Int = 32, val idBits: Int
   def toMemPort() = SimpleBus2MemPortConverter(this, new MemPortIo(32))
 
   def dump(name: String) = {
-    when (req.fire()) { printf(p"${GTimer()},[${name}] ${req.bits}\n") }
-    when (resp.fire()) { printf(p"${GTimer()},[${name}] ${resp.bits}\n") }
+    when (req.fire) { printf(p"${GTimer()},[${name}] ${req.bits}\n") }
+    when (resp.fire) { printf(p"${GTimer()},[${name}] ${resp.bits}\n") }
   }
 }
 

--- a/src/main/scala/bus/simplebus/ToAXI4.scala
+++ b/src/main/scala/bus/simplebus/ToAXI4.scala
@@ -102,7 +102,7 @@ class AXI42SimpleBusConverter() extends Module {
     }
   }
 
-  when (isState(axi_write) && axi.w.fire()) {
+  when (isState(axi_write) && axi.w.fire) {
     mem.req.valid := true.B
     req.cmd := Mux(aw_reg.len === 0.U, SimpleBusCmd.write,
       Mux(w.last, SimpleBusCmd.writeLast, SimpleBusCmd.writeBurst))
@@ -134,11 +134,11 @@ class AXI42SimpleBusConverter() extends Module {
   axi.b.valid := bresp_en && mem.resp.valid
   axi.b.bits.resp := AXI4Parameters.RESP_OKAY
 
-  when (axi.ar.fire()) { assert(mem.req.fire() && !isInflight()); }
-  when (axi.aw.fire()) { assert(!isInflight()); }
-  when (axi.w.fire()) { assert(mem.req .fire() && isState(axi_write)); }
-  when (axi.b.fire()) { assert(mem.resp.fire() && isState(axi_write)); }
-  when (axi.r.fire()) { assert(mem.resp.fire() && isState(axi_read)); }
+  when (axi.ar.fire) { assert(mem.req.fire && !isInflight()); }
+  when (axi.aw.fire) { assert(!isInflight()); }
+  when (axi.w.fire) { assert(mem.req .fire && isState(axi_write)); }
+  when (axi.b.fire) { assert(mem.resp.fire && isState(axi_write)); }
+  when (axi.r.fire) { assert(mem.resp.fire && isState(axi_read)); }
 }
 
 
@@ -184,10 +184,10 @@ class SimpleBus2AXI4Converter[OT <: AXI4Lite](outType: OT, isFromCache: Boolean)
   mem.resp.bits.cmd  := Mux(rlast, SimpleBusCmd.readLast, 0.U)
 
   val wSend = Wire(Bool())
-  val awAck = BoolStopWatch(axi.aw.fire(), wSend)
-  val wAck = BoolStopWatch(axi.w.fire() && wlast, wSend)
-  wSend := (axi.aw.fire() && axi.w.fire() && wlast) || (awAck && wAck)
-  val wen = RegEnable(mem.req.bits.isWrite(), mem.req.fire())
+  val awAck = BoolStopWatch(axi.aw.fire, wSend)
+  val wAck = BoolStopWatch(axi.w.fire && wlast, wSend)
+  wSend := (axi.aw.fire && axi.w.fire && wlast) || (awAck && wAck)
+  val wen = RegEnable(mem.req.bits.isWrite(), mem.req.fire)
 
   axi.ar.valid := mem.isRead()
   axi.aw.valid := mem.isWrite() && !awAck

--- a/src/main/scala/device/AXI4CLINT.scala
+++ b/src/main/scala/device/AXI4CLINT.scala
@@ -59,7 +59,7 @@ class AXI4CLINT(sim: Boolean = false) extends AXI4SlaveModule(new AXI4Lite, new 
   def getOffset(addr: UInt) = addr(15,0)
 
   RegMap.generate(mapping, getOffset(raddr), in.r.bits.data,
-    getOffset(waddr), in.w.fire(), in.w.bits.data, MaskExpand(in.w.bits.strb))
+    getOffset(waddr), in.w.fire, in.w.bits.data, MaskExpand(in.w.bits.strb))
 
   io.extra.get.mtip := RegNext(mtime >= mtimecmp)
   io.extra.get.msip := RegNext(msip =/= 0.U)

--- a/src/main/scala/device/AXI4DMA.scala
+++ b/src/main/scala/device/AXI4DMA.scala
@@ -50,20 +50,20 @@ class AXI4DMA extends AXI4SlaveModule(new AXI4Lite, new DMABundle) {
     }
   }
   when (state === s_idle && len =/= 0.U) { state := s_read_req }
-  when (state === s_read_req && dma.ar.fire()) { state := s_read_wait_resp }
-  when (state === s_read_wait_resp && dma.r.fire()) {
+  when (state === s_read_req && dma.ar.fire) { state := s_read_wait_resp }
+  when (state === s_read_wait_resp && dma.r.fire) {
     data := dma.r.bits.data.asTypeOf(Vec(8 / step, UInt(stepBits.W)))(src(2, log2Ceil(step)))
     state := s_write_req
   }
 
   val wSend = Wire(Bool())
   val wlast = dma.w.bits.last
-  val awAck = BoolStopWatch(dma.aw.fire(), wSend)
-  val wAck = BoolStopWatch(dma.w.fire() && wlast, wSend)
-  wSend := (dma.aw.fire() && dma.w.fire() && wlast) || (awAck && wAck)
+  val awAck = BoolStopWatch(dma.aw.fire, wSend)
+  val wAck = BoolStopWatch(dma.w.fire && wlast, wSend)
+  wSend := (dma.aw.fire && dma.w.fire && wlast) || (awAck && wAck)
 
   when (state === s_write_req && wSend) { state := s_write_wait_resp }
-  when (state === s_write_wait_resp && dma.b.fire()) {
+  when (state === s_write_wait_resp && dma.b.fire) {
     len := len - step.U
     dest := dest + step.U
     src := src + step.U
@@ -99,5 +99,5 @@ class AXI4DMA extends AXI4SlaveModule(new AXI4Lite, new DMABundle) {
   )
 
   RegMap.generate(mapping, raddr(3,0), in.r.bits.data,
-    waddr(3,0), in.w.fire(), in.w.bits.data, MaskExpand(in.w.bits.strb >> waddr(2,0)))
+    waddr(3,0), in.w.fire, in.w.bits.data, MaskExpand(in.w.bits.strb >> waddr(2,0)))
 }

--- a/src/main/scala/device/AXI4DummySD.scala
+++ b/src/main/scala/device/AXI4DummySD.scala
@@ -113,7 +113,7 @@ class AXI4DummySD extends AXI4SlaveModule(new AXI4Lite) with HasSDConst {
 
   val sdHelper = Module(new SDHelper)
   sdHelper.io.clk := clock
-  sdHelper.io.ren := (getOffset(raddr) === 0x40.U && io.in.ar.fire())
+  sdHelper.io.ren := (getOffset(raddr) === 0x40.U && io.in.ar.fire)
   sdHelper.io.setAddr := setAddr
   sdHelper.io.addr := regs(sdarg)
   def sdRead = sdHelper.io.data
@@ -138,7 +138,7 @@ class AXI4DummySD extends AXI4SlaveModule(new AXI4Lite) with HasSDConst {
              else Mux(waddr(2), in.w.bits.strb(7,4), in.w.bits.strb(3,0))
   val rdata = Wire(UInt(DataBits.W))
   RegMap.generate(mapping, getOffset(raddr), rdata,
-    getOffset(waddr), in.w.fire(), in.w.bits.data, MaskExpand(strb))
+    getOffset(waddr), in.w.fire, in.w.bits.data, MaskExpand(strb))
 
   in.r.bits.data := (if (DataBits == 32) RegEnable(RegNext(rdata(31,0)), ren)
                      else RegEnable(RegNext(Fill(2, rdata(31,0))), ren))

--- a/src/main/scala/device/AXI4Flash.scala
+++ b/src/main/scala/device/AXI4Flash.scala
@@ -36,7 +36,7 @@ class AXI4Flash extends AXI4SlaveModule(new AXI4Lite) {
 
   val rdata = Wire(UInt(64.W))
   RegMap.generate(mapping, getOffset(raddr), rdata,
-    getOffset(waddr), in.w.fire(), in.w.bits.data, MaskExpand(in.w.bits.strb))
+    getOffset(waddr), in.w.fire, in.w.bits.data, MaskExpand(in.w.bits.strb))
 
   in.r.bits.data := RegEnable(RegNext(Fill(2, rdata(31,0))), ren)
 }

--- a/src/main/scala/device/AXI4PLIC.scala
+++ b/src/main/scala/device/AXI4PLIC.scala
@@ -65,7 +65,7 @@ class AXI4PLIC(nrIntr: Int, nrHart: Int) extends AXI4SlaveModule(new AXI4Lite, n
   val claimCompletionMap = claimCompletion.zipWithIndex.map {
     case (r, hart) => {
       val addr = 0x200004 + hart * 0x1000
-      when (in.r.fire() && (getOffset(raddr) === addr.U)) { inHandle(r) := true.B }
+      when (in.r.fire && (getOffset(raddr) === addr.U)) { inHandle(r) := true.B }
       RegMap(addr, r, completionFn)
     }
   }.toMap
@@ -86,7 +86,7 @@ class AXI4PLIC(nrIntr: Int, nrHart: Int) extends AXI4SlaveModule(new AXI4Lite, n
 
   val rdata = Wire(UInt(32.W))
   RegMap.generate(mapping, getOffset(raddr), rdata,
-    getOffset(waddr), in.w.fire(), in.w.bits.data, MaskExpand(in.w.bits.strb >> waddr(2,0)))
+    getOffset(waddr), in.w.fire, in.w.bits.data, MaskExpand(in.w.bits.strb >> waddr(2,0)))
   // narrow read
   in.r.bits.data := Fill(2, rdata)
 

--- a/src/main/scala/device/AXI4RAM.scala
+++ b/src/main/scala/device/AXI4RAM.scala
@@ -47,7 +47,7 @@ class AXI4RAM[T <: AXI4Lite](_type: T = new AXI4, memByte: Int,
 
   val wIdx = index(waddr) + writeBeatCnt
   val rIdx = index(raddr) + readBeatCnt
-  val wen = in.w.fire() && inRange(wIdx)
+  val wen = in.w.fire && inRange(wIdx)
 
   val rdata = if (useBlackBox) {
     val mem = Module(new RAMHelper(memByte))

--- a/src/main/scala/device/AXI4Slave.scala
+++ b/src/main/scala/device/AXI4Slave.scala
@@ -40,20 +40,20 @@ abstract class AXI4SlaveModule[T <: AXI4Lite, B <: Data](_type :T = new AXI4, _e
     case axi4: AXI4 =>
       val c = Counter(256)
       val beatCnt = Counter(256)
-      val len = HoldUnless(axi4.ar.bits.len, axi4.ar.fire())
-      val burst = HoldUnless(axi4.ar.bits.burst, axi4.ar.fire())
+      val len = HoldUnless(axi4.ar.bits.len, axi4.ar.fire)
+      val burst = HoldUnless(axi4.ar.bits.burst, axi4.ar.fire)
       val wrapAddr = axi4.ar.bits.addr & ~(axi4.ar.bits.len.asTypeOf(UInt(PAddrBits.W)) << axi4.ar.bits.size)
-      raddr := HoldUnless(wrapAddr, axi4.ar.fire())
+      raddr := HoldUnless(wrapAddr, axi4.ar.fire)
       axi4.r.bits.last := (c.value === len)
       when (ren) {
         beatCnt.inc()
         when (burst === AXI4Parameters.BURST_WRAP && beatCnt.value === len) { beatCnt.value := 0.U }
       }
-      when (axi4.r.fire()) {
+      when (axi4.r.fire) {
         c.inc()
         when (axi4.r.bits.last) { c.value := 0.U }
       }
-      when (axi4.ar.fire()) {
+      when (axi4.ar.fire) {
         beatCnt.value := (axi4.ar.bits.addr >> axi4.ar.bits.size) & axi4.ar.bits.len
         when (axi4.ar.bits.len =/= 0.U && axi4.ar.bits.burst === AXI4Parameters.BURST_WRAP) {
           assert(axi4.ar.bits.len === 1.U || axi4.ar.bits.len === 3.U ||
@@ -67,19 +67,19 @@ abstract class AXI4SlaveModule[T <: AXI4Lite, B <: Data](_type :T = new AXI4, _e
       (0.U, true.B)
   }
 
-  val r_busy = BoolStopWatch(in.ar.fire(), in.r.fire() && rLast, startHighPriority = true)
+  val r_busy = BoolStopWatch(in.ar.fire, in.r.fire && rLast, startHighPriority = true)
   in.ar.ready := in.r.ready || !r_busy
   in.r.bits.resp := AXI4Parameters.RESP_OKAY
-  ren := RegNext(in.ar.fire(), init=false.B) || (in.r.fire() && !rLast)
-  in.r.valid := BoolStopWatch(ren && (in.ar.fire() || r_busy), in.r.fire(), startHighPriority = true)
+  ren := RegNext(in.ar.fire, init=false.B) || (in.r.fire && !rLast)
+  in.r.valid := BoolStopWatch(ren && (in.ar.fire || r_busy), in.r.fire, startHighPriority = true)
 
 
   val waddr = Wire(UInt())
   val (writeBeatCnt, wLast) = in match {
     case axi4: AXI4 =>
       val c = Counter(256)
-      waddr := HoldUnless(axi4.aw.bits.addr, axi4.aw.fire())
-      when (axi4.w.fire()) {
+      waddr := HoldUnless(axi4.aw.bits.addr, axi4.aw.fire)
+      when (axi4.w.fire) {
         c.inc()
         when (axi4.w.bits.last) { c.value := 0.U }
       }
@@ -90,18 +90,18 @@ abstract class AXI4SlaveModule[T <: AXI4Lite, B <: Data](_type :T = new AXI4, _e
       (0.U, true.B)
   }
 
-  val w_busy = BoolStopWatch(in.aw.fire(), in.b.fire(), startHighPriority = true)
+  val w_busy = BoolStopWatch(in.aw.fire, in.b.fire, startHighPriority = true)
   in.aw.ready := !w_busy
   in. w.ready := in.aw.valid || (w_busy)
   in.b.bits.resp := AXI4Parameters.RESP_OKAY
-  in.b.valid := BoolStopWatch(in.w.fire() && wLast, in.b.fire(), startHighPriority = true)
+  in.b.valid := BoolStopWatch(in.w.fire && wLast, in.b.fire, startHighPriority = true)
 
   in match {
     case axi4: AXI4 =>
-      axi4.b.bits.id   := RegEnable(axi4.aw.bits.id, axi4.aw.fire())
-      axi4.b.bits.user := RegEnable(axi4.aw.bits.user, axi4.aw.fire())
-      axi4.r.bits.id   := RegEnable(axi4.ar.bits.id, axi4.ar.fire())
-      axi4.r.bits.user := RegEnable(axi4.ar.bits.user, axi4.ar.fire())
+      axi4.b.bits.id   := RegEnable(axi4.aw.bits.id, axi4.aw.fire)
+      axi4.b.bits.user := RegEnable(axi4.aw.bits.user, axi4.aw.fire)
+      axi4.r.bits.id   := RegEnable(axi4.ar.bits.id, axi4.ar.fire)
+      axi4.r.bits.user := RegEnable(axi4.ar.bits.user, axi4.ar.fire)
     case axi4lite: AXI4Lite =>
   }
 }

--- a/src/main/scala/device/AXI4UART.scala
+++ b/src/main/scala/device/AXI4UART.scala
@@ -30,9 +30,9 @@ class AXI4UART extends AXI4SlaveModule(new AXI4Lite, _extra = new UARTIO)
   val stat = RegInit(1.U(32.W))
   val ctrl = RegInit(0.U(32.W))
 
-  io.extra.get.out.valid := (waddr(3,0) === 4.U && in.w.fire())
+  io.extra.get.out.valid := (waddr(3,0) === 4.U && in.w.fire)
   io.extra.get.out.ch := in.w.bits.data(7,0)
-  io.extra.get.in.valid := (raddr(3,0) === 0.U && in.r.fire())
+  io.extra.get.in.valid := (raddr(3,0) === 0.U && in.r.fire)
 
   val mapping = Map(
     RegMap(0x0, io.extra.get.in.ch, RegMap.Unwritable),
@@ -42,6 +42,6 @@ class AXI4UART extends AXI4SlaveModule(new AXI4Lite, _extra = new UARTIO)
   )
 
   RegMap.generate(mapping, raddr(3,0), in.r.bits.data,
-    waddr(3,0), in.w.fire(), in.w.bits.data, MaskExpand(in.w.bits.strb >> waddr(2,0))
+    waddr(3,0), in.w.fire, in.w.bits.data, MaskExpand(in.w.bits.strb >> waddr(2,0))
   )
 }

--- a/src/main/scala/device/AXI4VGA.scala
+++ b/src/main/scala/device/AXI4VGA.scala
@@ -70,7 +70,7 @@ class VGACtrlBundle extends Bundle {
 
 class VGACtrl extends AXI4SlaveModule(new AXI4Lite, new VGACtrlBundle) with HasVGAParameter {
   val fbSizeReg = Cat(FBWidth.U(16.W), FBHeight.U(16.W))
-  val sync = in.aw.fire()
+  val sync = in.aw.fire
 
   val mapping = Map(
     RegMap(0x0, fbSizeReg, RegMap.Unwritable),
@@ -78,7 +78,7 @@ class VGACtrl extends AXI4SlaveModule(new AXI4Lite, new VGACtrlBundle) with HasV
   )
 
   RegMap.generate(mapping, raddr(3,0), in.r.bits.data,
-    waddr(3,0), in.w.fire(), in.w.bits.data, MaskExpand(in.w.bits.strb))
+    waddr(3,0), in.w.fire, in.w.bits.data, MaskExpand(in.w.bits.strb))
 
   io.extra.get.sync := sync
 }
@@ -133,7 +133,7 @@ class AXI4VGA(sim: Boolean = false) extends Module with HasVGAParameter {
   io.in.fb.ar.ready := true.B
   io.in.fb.r.bits.data := 0.U
   io.in.fb.r.bits.resp := AXI4Parameters.RESP_OKAY
-  io.in.fb.r.valid := BoolStopWatch(io.in.fb.ar.fire(), io.in.fb.r.fire(), startHighPriority = true)
+  io.in.fb.r.valid := BoolStopWatch(io.in.fb.ar.fire, io.in.fb.r.fire, startHighPriority = true)
 
   def inRange(x: UInt, start: Int, end: Int) = (x >= start.U) && (x < end.U)
 
@@ -162,7 +162,7 @@ class AXI4VGA(sim: Boolean = false) extends Module with HasVGAParameter {
   fb.io.in.ar.valid := RegNext(nextPixel) && hCounterIs2
 
   fb.io.in.r.ready := true.B
-  val data = HoldUnless(fb.io.in.r.bits.data, fb.io.in.r.fire())
+  val data = HoldUnless(fb.io.in.r.bits.data, fb.io.in.r.fire)
   val color = if (Settings.get("IsRV32")) data(31, 0)
               else Mux(hCounter(1), data(63, 32), data(31, 0))
   io.vga.rgb := Mux(io.vga.valid, color(23, 0), 0.U)

--- a/src/main/scala/nutcore/backend/fu/CSR.scala
+++ b/src/main/scala/nutcore/backend/fu/CSR.scala
@@ -623,7 +623,7 @@ class CSR(implicit val p: NutCoreConfig) extends NutCoreModule with HasCSRConst{
   csrExceptionVec(loadPageFault) := hasLoadPageFault
   csrExceptionVec(storePageFault) := hasStorePageFault
   val iduExceptionVec = io.cfIn.exceptionVec
-  val raiseExceptionVec = csrExceptionVec.asUInt() | iduExceptionVec.asUInt()
+  val raiseExceptionVec = csrExceptionVec.asUInt | iduExceptionVec.asUInt
   val raiseException = raiseExceptionVec.orR
   val exceptionNO = ExcPriority.foldRight(0.U)((i: Int, sum: UInt) => Mux(raiseExceptionVec(i), i.U, sum))
   io.wenFix := raiseException
@@ -638,7 +638,7 @@ class CSR(implicit val p: NutCoreConfig) extends NutCoreModule with HasCSRConst{
   io.redirect.rtype := 0.U
   io.redirect.target := Mux(resetSatp, io.cfIn.pc + 4.U, Mux(raiseExceptionIntr, trapTarget, retTarget))
 
-  Debug(raiseExceptionIntr, "excin %b excgen %b", csrExceptionVec.asUInt(), iduExceptionVec.asUInt())
+  Debug(raiseExceptionIntr, "excin %b excgen %b", csrExceptionVec.asUInt, iduExceptionVec.asUInt)
   Debug(raiseExceptionIntr, "int/exc: pc %x int (%d):%x exc: (%d):%x\n",io.cfIn.pc, intrNO, io.cfIn.intrVec.asUInt, exceptionNO, raiseExceptionVec.asUInt)
   Debug(raiseExceptionIntr, "[MST] time %d pc %x mstatus %x mideleg %x medeleg %x mode %x\n", GTimer(), io.cfIn.pc, mstatus, mideleg , medeleg, priviledgeMode)
   Debug(io.redirect.valid, "redirect to %x\n", io.redirect.target)

--- a/src/main/scala/nutcore/backend/fu/MDU.scala
+++ b/src/main/scala/nutcore/backend/fu/MDU.scala
@@ -57,7 +57,7 @@ class Multiplier(len: Int) extends NutCoreModule {
   def DSPOutPipe[T <: Data](a: T) = RegNext(RegNext(RegNext(a)))
   val mulRes = (DSPInPipe(io.in.bits(0)).asSInt * DSPInPipe(io.in.bits(1)).asSInt)
   io.out.bits := DSPOutPipe(mulRes).asUInt
-  io.out.valid := DSPOutPipe(DSPInPipe(io.in.fire()))
+  io.out.valid := DSPOutPipe(DSPInPipe(io.in.fire))
 
   val busy = RegInit(false.B)
   when (io.in.valid && !busy) { busy := true.B }
@@ -75,7 +75,7 @@ class Divider(len: Int = 64) extends NutCoreModule {
 
   val s_idle :: s_log2 :: s_shift :: s_compute :: s_finish :: Nil = Enum(5)
   val state = RegInit(s_idle)
-  val newReq = (state === s_idle) && io.in.fire()
+  val newReq = (state === s_idle) && io.in.fire
 
   val (a, b) = (io.in.bits(0), io.in.bits(1))
   val divBy0 = b === 0.U(len.W)
@@ -178,11 +178,11 @@ class MDU extends NutCoreModule {
   val res = Mux(isDiv, divRes, mulRes)
   io.out.bits := Mux(isW, SignExt(res(31,0),XLEN), res)
 
-  val isDivReg = Mux(io.in.fire(), isDiv, RegNext(isDiv))
+  val isDivReg = Mux(io.in.fire, isDiv, RegNext(isDiv))
   io.in.ready := Mux(isDiv, div.io.in.ready, mul.io.in.ready)
   io.out.valid := Mux(isDivReg, div.io.out.valid, mul.io.out.valid)
 
   Debug("[FU-MDU] irv-orv %d %d - %d %d\n", io.in.ready, io.in.valid, io.out.ready, io.out.valid)
 
-  BoringUtils.addSource(mul.io.out.fire(), "perfCntCondMmulInstr")
+  BoringUtils.addSource(mul.io.out.fire, "perfCntCondMmulInstr")
 }

--- a/src/main/scala/nutcore/backend/fu/UnpipelinedLSU.scala
+++ b/src/main/scala/nutcore/backend/fu/UnpipelinedLSU.scala
@@ -113,7 +113,7 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
     //   storeQueue.io.enq.bits.src2 := src2
     //   storeQueue.io.enq.bits.wdata := io.wdata
     //   storeQueue.io.enq.bits.func := func
-    //   storeQueue.io.deq.ready := lsExecUnit.io.out.fire()
+    //   storeQueue.io.deq.ready := lsExecUnit.io.out.fire
     // }
     
     lsExecUnit.io.in.valid     := false.B
@@ -144,7 +144,7 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
           lsExecUnit.io.in.bits.src2 := DontCare
           lsExecUnit.io.in.bits.func := func
           lsExecUnit.io.wdata        := io.wdata
-          io.in.ready                := lsExecUnit.io.out.fire() || scInvalid
+          io.in.ready                := lsExecUnit.io.out.fire || scInvalid
           io.out.valid               := lsExecUnit.io.out.valid  || scInvalid
           state := s_idle
         }
@@ -162,10 +162,10 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
         lsExecUnit.io.in.bits.src2 := DontCare
         lsExecUnit.io.in.bits.func := func
         lsExecUnit.io.wdata        := io.wdata
-        io.in.ready                := lsExecUnit.io.out.fire() 
+        io.in.ready                := lsExecUnit.io.out.fire 
         io.out.valid               := lsExecUnit.io.out.valid  
         assert(!atomReq || !amoReq || !lrReq || !scReq)
-        when(io.out.fire()){state := s_idle}
+        when(io.out.fire){state := s_idle}
       }
 
       // is(s_load){
@@ -175,9 +175,9 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
       //   lsExecUnit.io.in.bits.src2 := src2
       //   lsExecUnit.io.in.bits.func := func
       //   lsExecUnit.io.wdata        := DontCare
-      //   io.in.ready                := lsExecUnit.io.out.fire()
+      //   io.in.ready                := lsExecUnit.io.out.fire
       //   io.out.valid               := lsExecUnit.io.out.valid
-      //   when(lsExecUnit.io.out.fire()){state := s_idle}//load finished
+      //   when(lsExecUnit.io.out.fire){state := s_idle}//load finished
       // }
 
       is(s_amo_l){
@@ -189,7 +189,7 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
         lsExecUnit.io.wdata        := DontCare
         io.in.ready                := false.B
         io.out.valid               := false.B
-        when(lsExecUnit.io.out.fire()){
+        when(lsExecUnit.io.out.fire){
           state := s_amo_a; 
           Debug("[AMO-L] lsExecUnit.io.out.bits %x addr %x src2 %x\n", lsExecUnit.io.out.bits, lsExecUnit.io.in.bits.src1, io.wdata)
         }
@@ -218,9 +218,9 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
         lsExecUnit.io.in.bits.src2 := DontCare
         lsExecUnit.io.in.bits.func := Mux(atomWidthD, LSUOpType.sd, LSUOpType.sw)
         lsExecUnit.io.wdata        := atomMemReg
-        io.in.ready                := lsExecUnit.io.out.fire()
-        io.out.valid               := lsExecUnit.io.out.fire()
-        when(lsExecUnit.io.out.fire()){
+        io.in.ready                := lsExecUnit.io.out.fire
+        io.out.valid               := lsExecUnit.io.out.fire
+        when(lsExecUnit.io.out.fire){
           state := s_idle; 
           Debug("[AMO-S] atomRegReg %x addr %x\n", atomRegReg, lsExecUnit.io.in.bits.src1)
         }
@@ -232,9 +232,9 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
         lsExecUnit.io.in.bits.src2 := DontCare
         lsExecUnit.io.in.bits.func := Mux(atomWidthD, LSUOpType.ld, LSUOpType.lw)
         lsExecUnit.io.wdata        := DontCare
-        io.in.ready                := lsExecUnit.io.out.fire()
-        io.out.valid               := lsExecUnit.io.out.fire()
-        when(lsExecUnit.io.out.fire()){
+        io.in.ready                := lsExecUnit.io.out.fire
+        io.out.valid               := lsExecUnit.io.out.fire
+        when(lsExecUnit.io.out.fire){
           state := s_idle; 
           Debug("[LR]\n")
         }
@@ -246,9 +246,9 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
         lsExecUnit.io.in.bits.src2 := DontCare
         lsExecUnit.io.in.bits.func := Mux(atomWidthD, LSUOpType.sd, LSUOpType.sw)
         lsExecUnit.io.wdata        := io.wdata
-        io.in.ready                := lsExecUnit.io.out.fire()
-        io.out.valid               := lsExecUnit.io.out.fire()
-        when(lsExecUnit.io.out.fire()){
+        io.in.ready                := lsExecUnit.io.out.fire
+        io.out.valid               := lsExecUnit.io.out.fire
+        when(lsExecUnit.io.out.fire){
           state := s_idle; 
           Debug("[SC] \n")
         }
@@ -260,14 +260,14 @@ class UnpipelinedLSU extends NutCoreModule with HasLSUConst {
       io.in.ready := true.B
     }
 
-  Debug(io.out.fire(), "[LSU-AGU] state %x inv %x inr %x\n", state, io.in.valid, io.in.ready)
+  Debug(io.out.fire, "[LSU-AGU] state %x inv %x inr %x\n", state, io.in.valid, io.in.ready)
     // controled by FSM 
     // io.in.ready := lsExecUnit.io.in.ready
     // lsExecUnit.io.wdata := io.wdata
     // io.out.valid := lsExecUnit.io.out.valid 
 
     //Set LR/SC bits
-    setLr := io.out.fire() && (lrReq || scReq)
+    setLr := io.out.fire && (lrReq || scReq)
     setLrVal := lrReq
     setLrAddr := src1
 
@@ -350,21 +350,21 @@ class LSExecUnit extends NutCoreModule {
 
   switch (state) {
     is (s_idle) { 
-      when (dmem.req.fire() && dtlbEnable)  { state := s_wait_tlb  }
-      when (dmem.req.fire() && !dtlbEnable) { state := s_wait_resp } 
-      //when (dmem.req.fire()) { state := Mux(isStore, s_partialLoad, s_wait_resp) }
+      when (dmem.req.fire && dtlbEnable)  { state := s_wait_tlb  }
+      when (dmem.req.fire && !dtlbEnable) { state := s_wait_resp } 
+      //when (dmem.req.fire) { state := Mux(isStore, s_partialLoad, s_wait_resp) }
     }
     is (s_wait_tlb) {
       when (dtlbFinish && dtlbPF ) { state := s_idle }
       when (dtlbFinish && !dtlbPF) { state := s_wait_resp/*Mux(isStore, s_partialLoad, s_wait_resp) */} 
     }
-    is (s_wait_resp) { when (dmem.resp.fire()) { state := Mux(partialLoad, s_partialLoad, s_idle) } }
+    is (s_wait_resp) { when (dmem.resp.fire) { state := Mux(partialLoad, s_partialLoad, s_idle) } }
     is (s_partialLoad) { state := s_idle }
   }
 
-  Debug(dmem.req.fire(), "[LSU] %x, size %x, wdata_raw %x, isStore %x\n", addr, func(1,0), io.wdata, isStore)
-  Debug(dmem.req.fire(), "[LSU] dtlbFinish:%d dtlbEnable:%d dtlbPF:%d state:%d addr:%x dmemReqFire:%d dmemRespFire:%d dmemRdata:%x\n",dtlbFinish, dtlbEnable, dtlbPF, state,  dmem.req.bits.addr, dmem.req.fire(), dmem.resp.fire(), dmem.resp.bits.rdata)
-  Debug(dtlbFinish && dtlbEnable, "[LSU] dtlbFinish:%d dtlbEnable:%d dtlbPF:%d state:%d addr:%x dmemReqFire:%d dmemRespFire:%d dmemRdata:%x\n",dtlbFinish, dtlbEnable, dtlbPF, state,  dmem.req.bits.addr, dmem.req.fire(), dmem.resp.fire(), dmem.resp.bits.rdata)
+  Debug(dmem.req.fire, "[LSU] %x, size %x, wdata_raw %x, isStore %x\n", addr, func(1,0), io.wdata, isStore)
+  Debug(dmem.req.fire, "[LSU] dtlbFinish:%d dtlbEnable:%d dtlbPF:%d state:%d addr:%x dmemReqFire:%d dmemRespFire:%d dmemRdata:%x\n",dtlbFinish, dtlbEnable, dtlbPF, state,  dmem.req.bits.addr, dmem.req.fire, dmem.resp.fire, dmem.resp.bits.rdata)
+  Debug(dtlbFinish && dtlbEnable, "[LSU] dtlbFinish:%d dtlbEnable:%d dtlbPF:%d state:%d addr:%x dmemReqFire:%d dmemRespFire:%d dmemRdata:%x\n",dtlbFinish, dtlbEnable, dtlbPF, state,  dmem.req.bits.addr, dmem.req.fire, dmem.resp.fire, dmem.resp.bits.rdata)
 
   val size = func(1,0)
   val reqAddr  = if (XLEN == 32) SignExt(addr, VAddrBits) else addr(VAddrBits-1,0)
@@ -379,10 +379,10 @@ class LSExecUnit extends NutCoreModule {
   dmem.req.valid := valid && (state === s_idle) && !io.loadAddrMisaligned && !io.storeAddrMisaligned
   dmem.resp.ready := true.B
 
-  io.out.valid := Mux( dtlbPF && state =/= s_idle || io.loadAddrMisaligned || io.storeAddrMisaligned, true.B, Mux(partialLoad, state === s_partialLoad, dmem.resp.fire() && (state === s_wait_resp)))
+  io.out.valid := Mux( dtlbPF && state =/= s_idle || io.loadAddrMisaligned || io.storeAddrMisaligned, true.B, Mux(partialLoad, state === s_partialLoad, dmem.resp.fire && (state === s_wait_resp)))
   io.in.ready := (state === s_idle) || dtlbPF
 
-  Debug(io.out.fire(), "[LSU-EXECUNIT] state %x dresp %x dpf %x lm %x sm %x\n", state, dmem.resp.fire(), dtlbPF, io.loadAddrMisaligned, io.storeAddrMisaligned)
+  Debug(io.out.fire, "[LSU-EXECUNIT] state %x dresp %x dpf %x lm %x sm %x\n", state, dmem.resp.fire, dtlbPF, io.loadAddrMisaligned, io.storeAddrMisaligned)
 
   val rdata = dmem.resp.bits.rdata
   val rdataLatch = RegNext(rdata)
@@ -431,8 +431,8 @@ class LSExecUnit extends NutCoreModule {
 
   Debug(io.loadAddrMisaligned || io.storeAddrMisaligned, "misaligned addr detected\n")
 
-  BoringUtils.addSource(dmem.isRead() && dmem.req.fire(), "perfCntCondMloadInstr")
-  BoringUtils.addSource(BoolStopWatch(dmem.isRead(), dmem.resp.fire()), "perfCntCondMloadStall")
-  BoringUtils.addSource(BoolStopWatch(dmem.isWrite(), dmem.resp.fire()), "perfCntCondMstoreStall")
+  BoringUtils.addSource(dmem.isRead() && dmem.req.fire, "perfCntCondMloadInstr")
+  BoringUtils.addSource(BoolStopWatch(dmem.isRead(), dmem.resp.fire), "perfCntCondMloadStall")
+  BoringUtils.addSource(BoolStopWatch(dmem.isWrite(), dmem.resp.fire), "perfCntCondMstoreStall")
   BoringUtils.addSource(io.isMMIO, "perfCntCondMmmioInstr")
 }

--- a/src/main/scala/nutcore/backend/ooo/ROB.scala
+++ b/src/main/scala/nutcore/backend/ooo/ROB.scala
@@ -438,8 +438,8 @@ class ROB(implicit val p: NutCoreConfig) extends NutCoreModule with HasInstrType
   }
 
   // Generate Debug Info
-    Debug(io.in(0).fire(), "[DISPATCH1] pc = 0x%x inst %x wen %x wdst %x\n", io.in(0).bits.cf.pc, io.in(0).bits.cf.instr, io.in(0).bits.ctrl.rfWen, io.in(0).bits.ctrl.rfDest)
-    Debug(io.in(1).fire(), "[DISPATCH2] pc = 0x%x inst %x wen %x wdst %x\n", io.in(1).bits.cf.pc, io.in(1).bits.cf.instr, io.in(1).bits.ctrl.rfWen, io.in(1).bits.ctrl.rfDest)
+    Debug(io.in(0).fire, "[DISPATCH1] pc = 0x%x inst %x wen %x wdst %x\n", io.in(0).bits.cf.pc, io.in(0).bits.cf.instr, io.in(0).bits.ctrl.rfWen, io.in(0).bits.ctrl.rfDest)
+    Debug(io.in(1).fire, "[DISPATCH2] pc = 0x%x inst %x wen %x wdst %x\n", io.in(1).bits.cf.pc, io.in(1).bits.cf.instr, io.in(1).bits.ctrl.rfWen, io.in(1).bits.ctrl.rfDest)
     Debug(io.cdb(0).valid, "[COMMIT1] pc = 0x%x inst %x wen %x wdst %x wdata = 0x%x\n", io.cdb(0).bits.decode.cf.pc, io.cdb(0).bits.decode.cf.instr, io.cdb(0).bits.decode.ctrl.rfWen, io.cdb(0).bits.decode.ctrl.rfDest, io.cdb(0).bits.commits)
     Debug(io.cdb(1).valid, "[COMMIT2] pc = 0x%x inst %x wen %x wdst %x wdata = 0x%x\n", io.cdb(1).bits.decode.cf.pc, io.cdb(1).bits.decode.cf.instr, io.cdb(1).bits.decode.ctrl.rfWen, io.cdb(1).bits.decode.ctrl.rfDest, io.cdb(1).bits.commits)
     Debug(retireATerm && valid(ringBufferTail)(0), "[RETIRE1] pc = 0x%x inst %x wen %x wdst %x wdata %x mmio %x intrNO %x\n", decode(ringBufferTail)(0).cf.pc, decode(ringBufferTail)(0).cf.instr, io.wb(0).rfWen, io.wb(0).rfDest, io.wb(0).rfData, isMMIO(ringBufferTail)(0), intrNO(ringBufferTail)(0))

--- a/src/main/scala/nutcore/backend/seq/EXU.scala
+++ b/src/main/scala/nutcore/backend/seq/EXU.scala
@@ -114,20 +114,20 @@ class EXU(implicit val p: NutCoreConfig) extends NutCoreModule {
   io.out.bits.commits(FuType.mdu) := mduOut
   io.out.bits.commits(FuType.mou) := 0.U
 
-  io.in.ready := !io.in.valid || io.out.fire()
+  io.in.ready := !io.in.valid || io.out.fire
 
   io.forward.valid := io.in.valid
   io.forward.wb.rfWen := io.in.bits.ctrl.rfWen
   io.forward.wb.rfDest := io.in.bits.ctrl.rfDest
-  io.forward.wb.rfData := Mux(alu.io.out.fire(), aluOut, lsuOut)
+  io.forward.wb.rfData := Mux(alu.io.out.fire, aluOut, lsuOut)
   io.forward.fuType := io.in.bits.ctrl.fuType
 
   val isBru = ALUOpType.isBru(fuOpType)
-  BoringUtils.addSource(alu.io.out.fire() && !isBru, "perfCntCondMaluInstr")
-  BoringUtils.addSource(alu.io.out.fire() && isBru, "perfCntCondMbruInstr")
-  BoringUtils.addSource(lsu.io.out.fire(), "perfCntCondMlsuInstr")
-  BoringUtils.addSource(mdu.io.out.fire(), "perfCntCondMmduInstr")
-  BoringUtils.addSource(csr.io.out.fire(), "perfCntCondMcsrInstr")
+  BoringUtils.addSource(alu.io.out.fire && !isBru, "perfCntCondMaluInstr")
+  BoringUtils.addSource(alu.io.out.fire && isBru, "perfCntCondMbruInstr")
+  BoringUtils.addSource(lsu.io.out.fire, "perfCntCondMlsuInstr")
+  BoringUtils.addSource(mdu.io.out.fire, "perfCntCondMmduInstr")
+  BoringUtils.addSource(csr.io.out.fire, "perfCntCondMcsrInstr")
 
   if (!p.FPGAPlatform) {
     val cycleCnt = WireInit(0.U(64.W))

--- a/src/main/scala/nutcore/backend/seq/ISU.scala
+++ b/src/main/scala/nutcore/backend/seq/ISU.scala
@@ -83,20 +83,20 @@ class ISU(implicit val p: NutCoreConfig) extends NutCoreModule with HasRegFilePa
   when (io.wb.rfWen) { rf.write(io.wb.rfDest, io.wb.rfData) }
 
   val wbClearMask = Mux(io.wb.rfWen && !isDepend(io.wb.rfDest, io.forward.wb.rfDest, forwardRfWen), sb.mask(io.wb.rfDest), 0.U(NRReg.W))
-  // val isuFireSetMask = Mux(io.out.fire(), sb.mask(rfDest), 0.U)
-  val isuFireSetMask = Mux(io.out.fire(), sb.mask(rfDest1), 0.U)
+  // val isuFireSetMask = Mux(io.out.fire, sb.mask(rfDest), 0.U)
+  val isuFireSetMask = Mux(io.out.fire, sb.mask(rfDest1), 0.U)
   when (io.flush) { sb.update(0.U, Fill(NRReg, 1.U(1.W))) }
   .otherwise { sb.update(isuFireSetMask, wbClearMask) }
 
-  io.in(0).ready := !io.in(0).valid || io.out.fire()
+  io.in(0).ready := !io.in(0).valid || io.out.fire
   io.in(1).ready := false.B
 
-  Debug(io.out.fire(), "issue: pc %x npc %x instr %x src1 %x src2 %x imm %x\n", io.out.bits.cf.pc, io.out.bits.cf.pnpc, io.out.bits.cf.instr, io.out.bits.data.src1, io.out.bits.data.src2, io.out.bits.data.imm)
+  Debug(io.out.fire, "issue: pc %x npc %x instr %x src1 %x src2 %x imm %x\n", io.out.bits.cf.pc, io.out.bits.cf.pnpc, io.out.bits.cf.instr, io.out.bits.data.src1, io.out.bits.data.src2, io.out.bits.data.imm)
 
   // read after write
   BoringUtils.addSource(io.in(0).valid && !io.out.valid, "perfCntCondMrawStall")
-  BoringUtils.addSource(io.out.valid && !io.out.fire(), "perfCntCondMexuBusy")
-  BoringUtils.addSource(io.out.fire(), "perfCntCondISUIssue")
+  BoringUtils.addSource(io.out.valid && !io.out.fire, "perfCntCondMexuBusy")
+  BoringUtils.addSource(io.out.fire, "perfCntCondISUIssue")
 
   if (!p.FPGAPlatform) {
     val difftest = Module(new DifftestArchIntRegState)

--- a/src/main/scala/nutcore/frontend/BPU.scala
+++ b/src/main/scala/nutcore/frontend/BPU.scala
@@ -102,7 +102,7 @@ class BPU_ooo extends NutCoreModule {
   // we should latch the input pc for one cycle
   val pcLatch = RegEnable(io.in.pc.bits, io.in.pc.valid)
   val btbHit = Wire(Vec(4, Bool()))
-  (0 to 3).map(i => btbHit(i) := btbRead(i).valid && btbRead(i).tag === btbAddr.getTag(pcLatch) && !flush && RegNext(btb(i).io.r.req.fire(), init = false.B))
+  (0 to 3).map(i => btbHit(i) := btbRead(i).valid && btbRead(i).tag === btbAddr.getTag(pcLatch) && !flush && RegNext(btb(i).io.r.req.fire, init = false.B))
   // btbHit will ignore pc(2,0). pc(2,0) is used to build brIdx
   val crosslineJump = btbRead(3).crosslineJump && btbHit(3) && !io.brIdx(0) && !io.brIdx(1) && !io.brIdx(2)
   io.crosslineJump := crosslineJump
@@ -317,7 +317,7 @@ class BPU_inorder extends NutCoreModule {
   // since there is one cycle latency to read SyncReadMem,
   // we should latch the input pc for one cycle
   val pcLatch = RegEnable(io.in.pc.bits, io.in.pc.valid)
-  val btbHit = btbRead.valid && btbRead.tag === btbAddr.getTag(pcLatch) && !flush && RegNext(btb.io.r.req.fire(), init = false.B) && !(pcLatch(1) && btbRead.brIdx(0))
+  val btbHit = btbRead.valid && btbRead.tag === btbAddr.getTag(pcLatch) && !flush && RegNext(btb.io.r.req.fire, init = false.B) && !(pcLatch(1) && btbRead.brIdx(0))
   // btbHit will ignore pc(1,0). pc(1,0) is used to build brIdx
   // !(pcLatch(1) && btbRead.brIdx(0)) is used to deal with the following case:
   // -------------------------------------------------

--- a/src/main/scala/nutcore/frontend/Frontend.scala
+++ b/src/main/scala/nutcore/frontend/Frontend.scala
@@ -74,7 +74,7 @@ class Frontend_embedded(implicit val p: NutCoreConfig) extends NutCoreModule wit
   val ifu  = Module(new IFU_embedded)
   val idu  = Module(new IDU)
 
-  PipelineConnect(ifu.io.out, idu.io.in(0), idu.io.out(0).fire(), ifu.io.flushVec(0))
+  PipelineConnect(ifu.io.out, idu.io.in(0), idu.io.out(0).fire, ifu.io.flushVec(0))
   idu.io.in(1) := DontCare
 
   io.out <> idu.io.out
@@ -103,7 +103,7 @@ class Frontend_inorder(implicit val p: NutCoreConfig) extends NutCoreModule with
   }
 
   PipelineConnect2(ifu.io.out, ibf.io.in, ifu.io.flushVec(0))
-  PipelineConnect(ibf.io.out, idu.io.in(0), idu.io.out(0).fire(), ifu.io.flushVec(1))
+  PipelineConnect(ibf.io.out, idu.io.in(0), idu.io.out(0).fire, ifu.io.flushVec(1))
   idu.io.in(1) := DontCare
 
   ibf.io.flush := ifu.io.flushVec(1)

--- a/src/main/scala/nutcore/frontend/IDU.scala
+++ b/src/main/scala/nutcore/frontend/IDU.scala
@@ -159,12 +159,12 @@ class Decoder(implicit val p: NutCoreConfig) extends NutCoreModule with HasInstr
 
   //output signals
   io.out.valid := io.in.valid
-  io.in.ready := !io.in.valid || io.out.fire() && !hasIntr
+  io.in.ready := !io.in.valid || io.out.fire && !hasIntr
   io.out.bits.cf <> io.in.bits
   // fix c_break
 
 
-  Debug(io.out.fire(), "issue: pc %x npc %x instr %x\n", io.out.bits.cf.pc, io.out.bits.cf.pnpc, io.out.bits.cf.instr)
+  Debug(io.out.fire, "issue: pc %x npc %x instr %x\n", io.out.bits.cf.pc, io.out.bits.cf.pnpc, io.out.bits.cf.instr)
 
   val intrVec = WireInit(0.U(12.W))
   BoringUtils.addSink(intrVec, "intrVecIDU")
@@ -211,7 +211,7 @@ class IDU(implicit val p: NutCoreConfig) extends NutCoreModule with HasInstrType
   val runahead = Module(new DifftestRunaheadEvent)
   runahead.io.clock         := clock
   runahead.io.coreid        := 0.U
-  runahead.io.valid         := io.out(0).fire()
+  runahead.io.valid         := io.out(0).fire
   runahead.io.branch        := decoder1.io.isBranch
   runahead.io.pc            := io.out(0).bits.cf.pc
   runahead.io.checkpoint_id := checkpoint_id

--- a/src/main/scala/nutcore/frontend/IFU.scala
+++ b/src/main/scala/nutcore/frontend/IFU.scala
@@ -55,7 +55,7 @@ class IFU_ooo extends NutCoreModule with HasResetVector {
   // val pcBrIdx = RegInit(0.U(4.W))
   val pcInstValid = RegInit("b1111".U)
   val pcUpdate = Wire(Bool())
-  pcUpdate := io.redirect.valid || io.imem.req.fire()
+  pcUpdate := io.redirect.valid || io.imem.req.fire
   val snpc = Cat(pc(VAddrBits-1, 3), 0.U(3.W)) + CacheReadWidth.U  // IFU will always ask icache to fetch next instline 
   // Note: we define instline as 8 Byte aligned data from icache 
 
@@ -74,7 +74,7 @@ class IFU_ooo extends NutCoreModule with HasResetVector {
     nlptarget_latch := nlp.io.out.target
   }
 
-  when (io.imem.req.fire() || io.redirect.valid) {
+  when (io.imem.req.fire || io.redirect.valid) {
     nlpvalidreg := false.B
     nlpbridx_latch := 0.U
     nlptarget_latch := 0.U
@@ -139,14 +139,14 @@ class IFU_ooo extends NutCoreModule with HasResetVector {
   brIdx := Mux(io.redirect.valid, 0.U, Mux(state === s_crosslineJump, 0.U, pbrIdx))
   
   // BP will be disabled shortly after a redirect request
-  nlp.io.in.pc.valid := io.imem.req.fire() // only predict when Icache accepts a request
+  nlp.io.in.pc.valid := io.imem.req.fire // only predict when Icache accepts a request
   nlp.io.in.pc.bits := npc  // predict one cycle early
   nlp.io.flush := io.redirect.valid // redirect means BPU may need to be updated
 
   // Multi-cycle branch predictor
   // Multi-cycle branch predictor will not be synthesized if EnableMultiCyclePredictor is set to false
   val mcp = Module(new DummyPredicter)
-  mcp.io.in.pc.valid := io.imem.req.fire()
+  mcp.io.in.pc.valid := io.imem.req.fire
   mcp.io.in.pc.bits := pc
   mcp.io.flush := io.redirect.valid
   mcp.io.ignore := state === s_crosslineJump
@@ -160,7 +160,7 @@ class IFU_ooo extends NutCoreModule with HasResetVector {
   mcpResultQueue.io.enq.valid := mcp.io.valid
   mcpResultQueue.io.enq.bits.redirect := mcp.io.out
   mcpResultQueue.io.enq.bits.brIdx := mcp.io.brIdx
-  mcpResultQueue.io.deq.ready := io.imem.resp.fire()
+  mcpResultQueue.io.deq.ready := io.imem.resp.fire
 
   val validMCPRedirect = 
     mcpResultQueue.io.deq.bits.redirect.valid && //mcp predicts branch
@@ -170,7 +170,7 @@ class IFU_ooo extends NutCoreModule with HasResetVector {
 
   //val bp2 = Module(new BPU_nodelay)
   //bp2.io.in.bits := io.out.bits
-  //bp2.io.in.valid := io.imem.resp.fire()
+  //bp2.io.in.valid := io.imem.resp.fire
 
   when (pcUpdate) { 
     pc := npc
@@ -201,8 +201,8 @@ class IFU_ooo extends NutCoreModule with HasResetVector {
   io.out.bits := DontCare
     //inst path only uses 32bit inst, get the right inst according to pc(2)
 
-  Debug(io.imem.req.fire(), "[IFI] pc=%x user=%x redirect %x pcInstValid %b brIdx %b npc %x pc %x pnpc %x\n", io.imem.req.bits.addr, io.imem.req.bits.user.getOrElse(0.U), io.redirect.valid, pcInstValid.asUInt, (pcInstValid & brIdx).asUInt, npc, pc, nlp.io.out.target)
-  Debug(io.out.fire(), "[IFO] pc=%x user=%x inst=%x npc=%x bridx %b valid %b ipf %x\n", io.out.bits.pc, io.imem.resp.bits.user.get, io.out.bits.instr, io.out.bits.pnpc, io.out.bits.brIdx.asUInt, io.out.bits.instValid.asUInt, io.ipf)
+  Debug(io.imem.req.fire, "[IFI] pc=%x user=%x redirect %x pcInstValid %b brIdx %b npc %x pc %x pnpc %x\n", io.imem.req.bits.addr, io.imem.req.bits.user.getOrElse(0.U), io.redirect.valid, pcInstValid.asUInt, (pcInstValid & brIdx).asUInt, npc, pc, nlp.io.out.target)
+  Debug(io.out.fire, "[IFO] pc=%x user=%x inst=%x npc=%x bridx %b valid %b ipf %x\n", io.out.bits.pc, io.imem.resp.bits.user.get, io.out.bits.instr, io.out.bits.pnpc, io.out.bits.brIdx.asUInt, io.out.bits.instValid.asUInt, io.ipf)
 
   // io.out.bits.instr := (if (XLEN == 64) io.imem.resp.bits.rdata.asTypeOf(Vec(2, UInt(32.W)))(io.out.bits.pc(2))
                       //  else io.imem.resp.bits.rdata)
@@ -242,7 +242,7 @@ class IFU_ooo extends NutCoreModule with HasResetVector {
     (0 until 4).map(i => maybeBranch(i) := preDecodeIsBranch(io.out.bits.instr(16*(i+1)-1, 16*i))) //TODO: use icache pre-decode result
     // When branch predicter set non-sequential npc for a non-branch inst,
     // flush IFU, fetch sequential inst instead.
-    when((brIdxByPredictor & ~maybeBranch.asUInt).orR && io.out.fire()){
+    when((brIdxByPredictor & ~maybeBranch.asUInt).orR && io.out.fire){
       Debug("[ERROR] FixInvalidBranchPredict\n")
       io.bpFlush := true.B
       io.out.bits.brIdx := 0.U
@@ -252,7 +252,7 @@ class IFU_ooo extends NutCoreModule with HasResetVector {
     // TODO: update BPU
   }
 
-  BoringUtils.addSource(BoolStopWatch(io.imem.req.valid, io.imem.resp.fire()), "perfCntCondMimemStall")
+  BoringUtils.addSource(BoolStopWatch(io.imem.req.valid, io.imem.resp.fire), "perfCntCondMimemStall")
   BoringUtils.addSource(io.flushVec.orR, "perfCntCondMifuFlush")
 }
 
@@ -268,7 +268,7 @@ class IFU_embedded extends NutCoreModule with HasResetVector {
 
   // pc
   val pc = RegInit(resetVector.U(32.W))
-  val pcUpdate = io.redirect.valid || io.imem.req.fire()
+  val pcUpdate = io.redirect.valid || io.imem.req.fire
   val snpc = pc + 4.U  // sequential next pc
 
   val bpu = Module(new BPU_embedded)
@@ -277,7 +277,7 @@ class IFU_embedded extends NutCoreModule with HasResetVector {
   val pnpc = bpu.io.out.target
   val npc = Mux(io.redirect.valid, io.redirect.target, Mux(bpu.io.out.valid, pnpc, snpc))
   
-  bpu.io.in.pc.valid := io.imem.req.fire() // only predict when Icache accepts a request
+  bpu.io.in.pc.valid := io.imem.req.fire // only predict when Icache accepts a request
   bpu.io.in.pc.bits := npc  // predict one cycle early
   bpu.io.flush := io.redirect.valid
 
@@ -299,10 +299,10 @@ class IFU_embedded extends NutCoreModule with HasResetVector {
   }
   io.out.valid := io.imem.resp.valid && !io.flushVec(0)
 
-  Debug(io.imem.req.fire(), "[IFI] pc=%x user=%x redirect %x npc %x pc %x pnpc %x\n", io.imem.req.bits.addr, io.imem.req.bits.user.getOrElse(0.U), io.redirect.valid, npc, pc, bpu.io.out.target)
-  Debug(io.out.fire(), "[IFO] pc=%x user=%x inst=%x npc=%x ipf %x\n", io.out.bits.pc, io.imem.resp.bits.user.get, io.out.bits.instr, io.out.bits.pnpc, io.ipf)
+  Debug(io.imem.req.fire, "[IFI] pc=%x user=%x redirect %x npc %x pc %x pnpc %x\n", io.imem.req.bits.addr, io.imem.req.bits.user.getOrElse(0.U), io.redirect.valid, npc, pc, bpu.io.out.target)
+  Debug(io.out.fire, "[IFO] pc=%x user=%x inst=%x npc=%x ipf %x\n", io.out.bits.pc, io.imem.resp.bits.user.get, io.out.bits.instr, io.out.bits.pnpc, io.ipf)
 
-  BoringUtils.addSource(BoolStopWatch(io.imem.req.valid, io.imem.resp.fire()), "perfCntCondMimemStall")
+  BoringUtils.addSource(BoolStopWatch(io.imem.req.valid, io.imem.resp.fire), "perfCntCondMimemStall")
   BoringUtils.addSource(io.flushVec.orR, "perfCntCondMifuFlush")
 }
 
@@ -320,7 +320,7 @@ class IFU_inorder extends NutCoreModule with HasResetVector {
 
   // pc
   val pc = RegInit(resetVector.U(VAddrBits.W))
-  val pcUpdate = io.redirect.valid || io.imem.req.fire()
+  val pcUpdate = io.redirect.valid || io.imem.req.fire
   val snpc = Mux(pc(1), pc + 2.U, pc + 4.U)  // sequential next pc
 
   val bp1 = Module(new BPU_inorder)
@@ -349,7 +349,7 @@ class IFU_inorder extends NutCoreModule with HasResetVector {
   brIdx := Cat(npcIsSeq, Mux(io.redirect.valid, 0.U, pbrIdx))
   //TODO: BP will be disabled shortly after a redirect request
 
-  bp1.io.in.pc.valid := io.imem.req.fire() // only predict when Icache accepts a request
+  bp1.io.in.pc.valid := io.imem.req.fire // only predict when Icache accepts a request
   bp1.io.in.pc.bits := npc  // predict one cycle early
 
   // Debug(bp1.io.in.pc.valid, p"pc: ${Hexadecimal(pc)} npc: ${Hexadecimal(npc)}\n")
@@ -376,8 +376,8 @@ class IFU_inorder extends NutCoreModule with HasResetVector {
   io.out.bits := DontCare
     //inst path only uses 32bit inst, get the right inst according to pc(2)
 
-  Debug(io.imem.req.fire(), "[IFI] pc=%x user=%x %x %x %x \n", io.imem.req.bits.addr, io.imem.req.bits.user.getOrElse(0.U), io.redirect.valid, pbrIdx, brIdx)
-  Debug(io.out.fire(), "[IFO] pc=%x inst=%x\n", io.out.bits.pc, io.out.bits.instr)
+  Debug(io.imem.req.fire, "[IFI] pc=%x user=%x %x %x %x \n", io.imem.req.bits.addr, io.imem.req.bits.user.getOrElse(0.U), io.redirect.valid, pbrIdx, brIdx)
+  Debug(io.out.fire, "[IFO] pc=%x inst=%x\n", io.out.bits.pc, io.out.bits.instr)
 
   // io.out.bits.instr := (if (XLEN == 64) io.imem.resp.bits.rdata.asTypeOf(Vec(2, UInt(32.W)))(io.out.bits.pc(2))
                       //  else io.imem.resp.bits.rdata)
@@ -390,6 +390,6 @@ class IFU_inorder extends NutCoreModule with HasResetVector {
   io.out.bits.exceptionVec(instrPageFault) := io.ipf
   io.out.valid := io.imem.resp.valid && !io.flushVec(0)
 
-  BoringUtils.addSource(BoolStopWatch(io.imem.req.valid, io.imem.resp.fire()), "perfCntCondMimemStall")
+  BoringUtils.addSource(BoolStopWatch(io.imem.req.valid, io.imem.resp.fire), "perfCntCondMimemStall")
   BoringUtils.addSource(io.flushVec.orR, "perfCntCondMifuFlush")
 }

--- a/src/main/scala/nutcore/frontend/NaiveIBF.scala
+++ b/src/main/scala/nutcore/frontend/NaiveIBF.scala
@@ -101,8 +101,8 @@ class NaiveRVCAlignBuffer extends NutCoreModule with HasInstrType with HasExcept
         canIn := rvcFinish || rvcForceLoadNext
         pcOut := io.in.bits.pc
         pnpcOut := Mux(rvcFinish, io.in.bits.pnpc, Mux(isRVC, io.in.bits.pc+2.U, io.in.bits.pc+4.U))
-        when(io.out.fire() && rvcFinish){state := s_idle}
-        when(io.out.fire() && rvcNext){
+        when(io.out.fire && rvcFinish){state := s_idle}
+        when(io.out.fire && rvcNext){
           state := s_extra
           pcOffsetR := pcOffset + Mux(isRVC, 2.U, 4.U)
         }
@@ -125,8 +125,8 @@ class NaiveRVCAlignBuffer extends NutCoreModule with HasInstrType with HasExcept
         canIn := rvcFinish || rvcForceLoadNext
         pcOut := Cat(io.in.bits.pc(VAddrBits-1,3), pcOffsetR(2,0)) 
         pnpcOut := Mux(rvcFinish, io.in.bits.pnpc, Mux(isRVC, pcOut+2.U, pcOut+4.U))
-        when(io.out.fire() && rvcFinish){state := s_idle}
-        when(io.out.fire() && rvcNext){
+        when(io.out.fire && rvcFinish){state := s_idle}
+        when(io.out.fire && rvcNext){
           state := s_extra
           pcOffsetR := pcOffset + Mux(isRVC, 2.U, 4.U)
         }
@@ -151,7 +151,7 @@ class NaiveRVCAlignBuffer extends NutCoreModule with HasInstrType with HasExcept
         // pnpcOut := Mux(rvcFinish, io.in.bits.pnpc, Mux(isRVC, pcOut+2.U, pcOut+4.U))
         canGo := io.in.valid
         canIn := false.B
-        when(io.out.fire()){
+        when(io.out.fire){
           state := s_extra
           pcOffsetR := "b010".U
         }
@@ -163,7 +163,7 @@ class NaiveRVCAlignBuffer extends NutCoreModule with HasInstrType with HasExcept
         // pnpcOut := Mux(rvcFinish, io.in.bits.pnpc, Mux(isRVC, pcOut+2.U, pcOut+4.U))
         canGo := io.in.valid
         canIn := true.B
-        when(io.out.fire()){
+        when(io.out.fire){
           state := s_idle
         }
       }
@@ -185,7 +185,7 @@ class NaiveRVCAlignBuffer extends NutCoreModule with HasInstrType with HasExcept
   io.out.bits.brIdx := Mux((pnpcOut === pcOut+4.U && !isRVC) || (pnpcOut === pcOut+2.U && isRVC), false.B, true.B)
 
   io.out.valid := io.in.valid && canGo
-  io.in.ready := (!io.in.valid || (io.out.fire() && canIn) || loadNextInstline)
+  io.in.ready := (!io.in.valid || (io.out.fire && canIn) || loadNextInstline)
 
   io.out.bits.exceptionVec := io.in.bits.exceptionVec
   io.out.bits.exceptionVec(instrPageFault) := io.in.bits.exceptionVec(instrPageFault) || specialIPFR && (state === s_waitnext_thenj || state === s_waitnext)

--- a/src/main/scala/nutcore/utils/WritebackDelayer.scala
+++ b/src/main/scala/nutcore/utils/WritebackDelayer.scala
@@ -43,19 +43,19 @@ class WritebackDelayer(bru: Boolean = false, name: String = "unnamedDelayer") ex
   }
 
   brMask := updateBrMask(brMask)
-  when(io.in.fire()){brMask := updateBrMask(io.in.bits.brMask)}
-  when(needMispredictionRecovery(brMask) || io.out.fire()){valid := false.B}
-  when(io.in.fire()){valid := true.B}
+  when(io.in.fire){brMask := updateBrMask(io.in.bits.brMask)}
+  when(needMispredictionRecovery(brMask) || io.out.fire){valid := false.B}
+  when(io.in.fire){valid := true.B}
   when(io.flush) {valid := false.B}
 
-  io.in.ready := (!valid || io.out.fire()) && !needMispredictionRecovery(io.in.bits.brMask)
-  io.out.bits <> RegEnable(io.in.bits, io.in.fire())
+  io.in.ready := (!valid || io.out.fire) && !needMispredictionRecovery(io.in.bits.brMask)
+  io.out.bits <> RegEnable(io.in.bits, io.in.fire)
   io.out.bits.brMask := brMask
   io.out.valid := valid
 
   if(bru){
-    io.freeCheckpoint.get.bits <> RegEnable(io.checkpointIn.get, io.in.fire())
-    io.freeCheckpoint.get.valid := io.out.fire()
+    io.freeCheckpoint.get.bits <> RegEnable(io.checkpointIn.get, io.in.fire)
+    io.freeCheckpoint.get.valid := io.out.fire
   }
 
   Debug(valid, "[WBDelay-"+name+"] delayer valid: pc %x brMask %x\n", io.out.bits.decode.cf.pc, brMask)

--- a/src/main/scala/sim/MeipGen.scala
+++ b/src/main/scala/sim/MeipGen.scala
@@ -36,7 +36,7 @@ class AXI4MeipGen extends AXI4SlaveModule(new AXI4Lite, new MeipGenIO) {
 
   def getOffset(addr: UInt) = addr(3, 0)
   RegMap.generate(mapping, getOffset(raddr), in.r.bits.data,
-    getOffset(waddr), in.w.fire(), in.w.bits.data, MaskExpand(in.w.bits.strb))
+    getOffset(waddr), in.w.fire, in.w.bits.data, MaskExpand(in.w.bits.strb))
 
   io.extra.get.meip := meip
 }

--- a/src/main/scala/system/Coherence.scala
+++ b/src/main/scala/system/Coherence.scala
@@ -73,27 +73,27 @@ class CoherenceManager extends Module with HasCoherenceParameter {
 
   switch (state) {
     is (s_idle) {
-      when (thisReq.fire()) {
+      when (thisReq.fire) {
         when (thisReq.bits.isRead()) { state := Mux(supportCoh.B, s_probeResp, s_memReadResp) }
         .elsewhen (thisReq.bits.isWriteLast()) { state := s_memWriteResp }
       }
     }
     is (s_probeResp) {
-      when (io.out.coh.resp.fire()) {
+      when (io.out.coh.resp.fire) {
         state := Mux(io.out.coh.resp.bits.isProbeHit(), s_probeForward, s_memReadReq)
       }
     }
     is (s_probeForward) {
       val thisResp = io.in.resp
       thisResp <> io.out.coh.resp
-      when (thisResp.fire() && thisResp.bits.isReadLast()) { state := s_idle }
+      when (thisResp.fire && thisResp.bits.isReadLast()) { state := s_idle }
     }
     is (s_memReadReq) {
       io.out.mem.req.bits := reqLatch
       io.out.mem.req.valid := true.B
-      when (io.out.mem.req.fire()) { state := s_memReadResp }
+      when (io.out.mem.req.fire) { state := s_memReadResp }
     }
-    is (s_memReadResp) { when (io.out.mem.resp.fire() && io.out.mem.resp.bits.isReadLast()) { state := s_idle } }
-    is (s_memWriteResp) { when (io.out.mem.resp.fire()) { state := s_idle } }
+    is (s_memReadResp) { when (io.out.mem.resp.fire && io.out.mem.resp.bits.isReadLast()) { state := s_idle } }
+    is (s_memWriteResp) { when (io.out.mem.resp.fire) { state := s_idle } }
   }
 }

--- a/src/main/scala/system/Prefetcher.scala
+++ b/src/main/scala/system/Prefetcher.scala
@@ -39,7 +39,7 @@ class Prefetcher extends Module with HasPrefetcherParameter {
   prefetchReq.cmd := SimpleBusCmd.prefetch
   prefetchReq.addr := io.in.bits.addr + XLEN.U
 
-  val lastReqAddr = (RegEnable(io.in.bits.addr, io.in.fire()))
+  val lastReqAddr = (RegEnable(io.in.bits.addr, io.in.fire))
   val thisReqAddr = io.in.bits.addr
   val lineMask = Cat(Fill(AddrBits - 6, 1.U(1.W)), 0.U(6.W))
   val neqAddr = (thisReqAddr & lineMask) =/= (lastReqAddr & lineMask)
@@ -47,13 +47,13 @@ class Prefetcher extends Module with HasPrefetcherParameter {
   when (!getNewReq) {
     io.out.bits <> io.in.bits
     io.out.valid := io.in.valid
-    io.in.ready := !io.in.valid || io.out.fire()
-    getNewReq := io.in.fire() && io.in.bits.isBurst() && neqAddr
+    io.in.ready := !io.in.valid || io.out.fire
+    getNewReq := io.in.fire && io.in.bits.isBurst() && neqAddr
   }.otherwise {
     io.out.bits <> prefetchReq
     io.out.valid := !AddressSpace.isMMIO(prefetchReq.addr)
     io.in.ready := false.B
-    getNewReq := !(io.out.fire() || AddressSpace.isMMIO(prefetchReq.addr))
+    getNewReq := !(io.out.fire || AddressSpace.isMMIO(prefetchReq.addr))
   }
   
   Debug() {

--- a/src/main/scala/utils/PipelineVector.scala
+++ b/src/main/scala/utils/PipelineVector.scala
@@ -37,10 +37,10 @@ object PipelineVector2Connect {
     needEnqueue(0) := in1.valid
     needEnqueue(1) := in2.valid
 
-    val enqueueSize = needEnqueue(0).asUInt()+&needEnqueue(1).asUInt() // count(true) in needEnqueue
+    val enqueueSize = needEnqueue(0).asUInt+&needEnqueue(1).asUInt // count(true) in needEnqueue
     val enqueueFire = (0 to 1).map(i => enqueueSize >= (i+1).U)
 
-    val wen = in1.fire() || in2.fire() // i.e. ringBufferAllowin && in.valid
+    val wen = in1.fire || in2.fire // i.e. ringBufferAllowin && in.valid
     when(wen){
         when(enqueueFire(0)){dataBuffer(0.U + ringBufferHead) := Mux(needEnqueue(0), in1.bits, in2.bits)}
         when(enqueueFire(1)){dataBuffer(1.U + ringBufferHead) := in2.bits}
@@ -61,7 +61,7 @@ object PipelineVector2Connect {
     out2.valid := ringBufferHead =/= deq2_StartIndex && out1.valid
 
     //dequeue control
-    val dequeueSize = out1.fire().asUInt() +& out2.fire().asUInt
+    val dequeueSize = out1.fire.asUInt +& out2.fire.asUInt
     val dequeueFire = dequeueSize > 0.U
     when(dequeueFire){
         ringBufferTail := ringBufferTail + dequeueSize;
@@ -74,7 +74,7 @@ object PipelineVector2Connect {
     }
 
     Debug(){
-        printf("[DPQ] size %x head %x tail %x enq %x deq %x\n", (bufferSize.asUInt() +& ringBufferHead.asUInt() - ringBufferTail.asUInt()) % bufferSize.asUInt(), ringBufferHead, ringBufferTail ,enqueueSize, dequeueSize)
+        printf("[DPQ] size %x head %x tail %x enq %x deq %x\n", (bufferSize.asUInt +& ringBufferHead.asUInt - ringBufferTail.asUInt) % bufferSize.asUInt, ringBufferHead, ringBufferTail ,enqueueSize, dequeueSize)
     }
 
   }

--- a/src/main/scala/utils/SRAMTemplate.scala
+++ b/src/main/scala/utils/SRAMTemplate.scala
@@ -127,6 +127,6 @@ class SRAMTemplateWithArbiter[T <: Data](nRead: Int, gen: T, set: Int, way: Int 
 
   // latch read results
   io.r.map{ case r => {
-    r.resp.data := HoldUnless(ram.io.r.resp.data, RegNext(r.req.fire()))
+    r.resp.data := HoldUnless(ram.io.r.resp.data, RegNext(r.req.fire))
   }}
 }

--- a/src/test/scala/cache/CacheTest.scala
+++ b/src/test/scala/cache/CacheTest.scala
@@ -64,10 +64,10 @@ class NutCoreSimTop extends Module {
   val initCnt = Counter(NRmemBlock)
   switch (state) {
     is (s_init_req) {
-      when (in.req.fire()) { state := s_init_resp }
+      when (in.req.fire) { state := s_init_resp }
     }
     is (s_init_resp) {
-      when (in.resp.fire()) {
+      when (in.resp.fire) {
         val wrap = initCnt.inc()
         state := Mux(wrap, s_test, s_init_req)
         when (wrap) {
@@ -107,23 +107,23 @@ class NutCoreSimTop extends Module {
   in.resp.ready := rand.readyChoose =/= 0.U
 
   val cohInflight = RegInit(false.B)
-  when (cohIn.resp.fire()) {
+  when (cohIn.resp.fire) {
     val resp = cohIn.resp.bits
     val isProbeEnd = resp.isProbeMiss() || (resp.cmd === SimpleBusCmd.readLast)
     when (isProbeEnd) { cohInflight := false.B }
   }
-  when (cohIn.req.fire()) { cohInflight := true.B }
+  when (cohIn.req.fire) { cohInflight := true.B }
 
   cohIn.req.bits.apply(addr = rand.cohAddr * 8.U + memBase.U, size = "b11".U,
     wdata = 0.U, wmask = 0.U, cmd = SimpleBusCmd.probe)
   cohIn.req.valid := (state === s_test) && rand.cohChoose === 0.U && !cohInflight
   cohIn.resp.ready := rand.cohReadyChoose =/= 0.U
 
-  when (Counter((state === s_test) && in.resp.fire(), printCnt)._2) { printf(".") }
-  when (Counter((state === s_test) && cohIn.req.fire(), printCnt)._2) { printf("@") }
+  when (Counter((state === s_test) && in.resp.fire, printCnt)._2) { printf(".") }
+  when (Counter((state === s_test) && cohIn.req.fire, printCnt)._2) { printf("@") }
 
   Debug(false) {
-    when (in.req.fire()) { printf(p"${GTimer()},[in.req] ${in.req.bits}\n") }
+    when (in.req.fire) { printf(p"${GTimer()},[in.req] ${in.req.bits}\n") }
   }
 
   def checkData(addr: UInt, data: UInt): Bool = data === Fill(2, addr)
@@ -150,7 +150,7 @@ class NutCoreSimTop extends Module {
   }
 
   // check rdata from cohIn
-  val cohAddr = RegEnable(cohIn.req.bits.addr(31,0), cohIn.req.fire())
+  val cohAddr = RegEnable(cohIn.req.bits.addr(31,0), cohIn.req.fire)
   when (cohIn.resp.valid) {
     val resp = cohIn.resp.bits
     val isRead = resp.cmd === SimpleBusCmd.readLast || resp.cmd === SimpleBusCmd.read


### PR DESCRIPTION
in build.sc:
reflective access of structural type member value out should be enabled by making the implicit value scala.language.reflectiveCalls visible.

in other files:
method fire in class AddMethodsToReadyValid is deprecated (since Chisel 3.5): Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead