### PR TITLE
fpga: update Vivado project files

### DIFF
--- a/fpga/board/common.tcl
+++ b/fpga/board/common.tcl
@@ -44,9 +44,18 @@ add_files -norecurse -fileset sources_1 $inc_files
 set_property is_global_include true [get_files $inc_files]
 
 # Add files for nutshell
-lappend src_files "[file normalize "${fpga_dir}/../build/TopMain.v"]"
+lappend src_files "[file normalize "${fpga_dir}/../build/TopMain.v"]" \
+                  "[file normalize "${fpga_dir}/../build/DifftestRunaheadEvent.v"]" \
+                  "[file normalize "${fpga_dir}/../build/DifftestRunaheadRedirectEvent.v"]"
 
 add_files -norecurse -fileset sources_1 $src_files
+
+# Mark file type of difftest files as SystemVerilog to support DPI statements
+set_property file_type SystemVerilog -objects [get_files -of_objects [get_filesets sources_1] [list \
+  "*/DifftestRunaheadRedirectEvent.v" \
+  "*/DifftestRunaheadEvent.v" \
+]]
+
 if {[info exists xdc_files]} {
   add_files -norecurse -fileset constrs_1 $xdc_files
 }

--- a/fpga/board/pynq/mk.tcl
+++ b/fpga/board/pynq/mk.tcl
@@ -5,7 +5,6 @@ set script_dir  [file dirname [info script]]
 
 # Add files for system top
 set src_files [list \
-  "[file normalize "${script_dir}/../../../src/test/vsrc/monitor.v"]" \
 ]
 
 # Add files for constraint


### PR DESCRIPTION
Hi, the first commit in this PR removes monitor.v, which was removed since the newer difftest framework was adopted in #63. The second adds difftest stubs files to the project, so the `module not found` error in Vivado can be resolved.