### PR TITLE
mem/EmbeddedTLB: fix connections of module EmbeddedTLB_fake

### DIFF
--- a/src/main/scala/nutcore/mem/EmbeddedTLB.scala
+++ b/src/main/scala/nutcore/mem/EmbeddedTLB.scala
@@ -407,6 +407,7 @@ class EmbeddedTLBEmpty(implicit val tlbConfig: TLBConfig) extends TlbModule {
 }
 
 class EmbeddedTLB_fake(implicit val tlbConfig: TLBConfig) extends TlbModule with HasTLBIO {
+  io.mem <> DontCare
   io.out <> io.in
   io.csrMMU.loadPF := false.B
   io.csrMMU.storePF := false.B
@@ -417,20 +418,15 @@ class EmbeddedTLB_fake(implicit val tlbConfig: TLBConfig) extends TlbModule with
 
 object EmbeddedTLB {
   def apply(in: SimpleBusUC, mem: SimpleBusUC, flush: Bool, csrMMU: MMUIO, enable: Boolean = true)(implicit tlbConfig: TLBConfig) = {
-    if (enable) {
-      val tlb = Module(new EmbeddedTLB)
-      tlb.io.in <> in
-      tlb.io.mem <> mem
-      tlb.io.flush := flush
-      tlb.io.csrMMU <> csrMMU
-      tlb
+    val tlb = if (enable) {
+      Module(new EmbeddedTLB)
     } else {
-      val tlb = Module(new EmbeddedTLB_fake)
-      tlb.io.in <> in
-      tlb.io.flush := flush
-      tlb.io.csrMMU <> csrMMU
-      mem := DontCare
-      tlb
+      Module(new EmbeddedTLB_fake)
     }
+    tlb.io.in <> in
+    tlb.io.mem <> mem
+    tlb.io.flush := flush
+    tlb.io.csrMMU <> csrMMU
+    tlb
   }
 }


### PR DESCRIPTION
This patch fixes errors generated when TLBs are disabled (#79). Changes are based on [this comment](https://github.com/OSCPU/NutShell/issues/73#issuecomment-1061337589) in #73.