### PR TITLE
fpga: fix multi board building

### DIFF
--- a/fpga/Makefile
+++ b/fpga/Makefile
@@ -16,6 +16,7 @@ VIVADO_FLAG = -nolog -nojournal -notrace
 PRJ_ROOT = board/$(BOARD)/build/$(PRJ_FULL)
 XPR_FILE = $(PRJ_ROOT)/$(PRJ_FULL).xpr
 $(XPR_FILE):
+	make -C .. clean
 	make -C .. BOARD=$(BOARD)
 	vivado $(VIVADO_FLAG) -mode batch -source board/$(BOARD)/mk.tcl -tclargs $(PRJ_FULL) $(STANDALONE)
 


### PR DESCRIPTION
After building the project for the pynq board and then building the project for the PXIe board, an error will occur, and using "make" when the verilog code exists will not make changes. The pynq setting is still used in Topmain.v, which will cause an error in the MMIO base.