### PR TITLE
Difftest: update difftest for vector extension

### DIFF
--- a/src/main/scala/nutcore/backend/ooo/ROB.scala
+++ b/src/main/scala/nutcore/backend/ooo/ROB.scala
@@ -509,9 +509,11 @@ class ROB(implicit val p: NutCoreConfig) extends NutCoreModule with HasInstrType
       difftest_commit.io.isRVC    := RegNext(decode(ringBufferTail)(i).cf.isRVC)
       difftest_commit.io.rfwen    := RegNext(io.wb(i).rfWen && io.wb(i).rfDest =/= 0.U) // && valid(ringBufferTail)(i) && commited(ringBufferTail)(i)
       difftest_commit.io.fpwen    := false.B
+      difftest_commit.io.vecwen   := false.B
       // difftest.io.wdata    := RegNext(io.wb(i).rfData)
       difftest_commit.io.wdest    := RegNext(io.wb(i).rfDest)
       difftest_commit.io.wpdest   := RegNext(io.wb(i).rfDest)
+      difftest_commit.io.uopIdx   := "b11111".U
 
       val difftest_wb = Module(new DifftestIntWriteback)
       difftest_wb.io.clock := clock

--- a/src/main/scala/nutcore/backend/seq/WBU.scala
+++ b/src/main/scala/nutcore/backend/seq/WBU.scala
@@ -69,9 +69,11 @@ class WBU(implicit val p: NutCoreConfig) extends NutCoreModule{
     difftest_commit.io.isRVC    := RegNext(io.in.bits.decode.cf.instr(1,0)=/="b11".U)
     difftest_commit.io.rfwen    := RegNext(io.wb.rfWen && io.wb.rfDest =/= 0.U) // && valid(ringBufferTail)(i) && commited(ringBufferTail)(i)
     difftest_commit.io.fpwen    := false.B
+    difftest_commit.io.vecwen   := false.B
     // difftest.io.wdata    := RegNext(io.wb.rfData)
     difftest_commit.io.wdest    := RegNext(io.wb.rfDest)
     difftest_commit.io.wpdest   := RegNext(io.wb.rfDest)
+    difftest_commit.io.uopIdx   := "b11111".U
 
     val difftest_wb = Module(new DifftestIntWriteback)
     difftest_wb.io.clock := clock


### PR DESCRIPTION
Now difftest checks whether an instruction is committed successfully, by checking uopidx == 0x1f