### PR TITLE
CSR: initialize mepc to zero

### DIFF
--- a/src/main/scala/nutcore/backend/fu/CSR.scala
+++ b/src/main/scala/nutcore/backend/fu/CSR.scala
@@ -253,7 +253,7 @@ class CSR(implicit val p: NutCoreConfig) extends NutCoreModule with HasCSRConst{
   val mcounteren = RegInit(UInt(XLEN.W), 0.U)
   val mcause = RegInit(UInt(XLEN.W), 0.U)
   val mtval = RegInit(UInt(XLEN.W), 0.U)
-  val mepc = Reg(UInt(XLEN.W))
+  val mepc = RegInit(UInt(XLEN.W), 0.U)
 
   val mie = RegInit(0.U(XLEN.W))
   val mipWire = WireInit(0.U.asTypeOf(new Interrupt))


### PR DESCRIPTION
The least significant bit of mepc should be zero. This is a temp fix to co-simulate ready-to-run/microbench.bin with Spike.