### PR TITLE
Move DifftestModule.finish to the top-level module

### DIFF
--- a/src/main/scala/sim/NutShellSim.scala
+++ b/src/main/scala/sim/NutShellSim.scala
@@ -66,4 +66,6 @@ class SimTop extends Module {
   BoringUtils.addSink(dummyWire, "DISPLAY_ENABLE")
 
   io.uart <> mmio.io.uart
+
+  DifftestModule.finish("nutshell")
 }

--- a/src/main/scala/top/TopMain.scala
+++ b/src/main/scala/top/TopMain.scala
@@ -72,5 +72,4 @@ object TopMain extends App {
       ChiselGeneratorAnnotation(() => new Top))
     )
   }
-  DifftestModule.finish("nutshell")
 }


### PR DESCRIPTION
This would allow the finish function to implement hardware logics within the elaboration scope.