### PR TITLE
MakeFile & CI: support chisel-cross in make verilog and add CI test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
             source ./env.sh
             wget https://github.com/llvm/circt/releases/download/firtool-1.56.1/firrtl-bin-linux-x64.tar.gz
             tar -xzf firrtl-bin-linux-x64.tar.gz
-            export FIRTOOL_BIN=$(pwd)/firtool-1.56.1/bin/firtool
+            echo "FIRTOOL_BIN=$(pwd)/firtool-1.56.1/bin/firtool" >> $GITHUB_ENV
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,30 @@ jobs:
             cp -r $GITHUB_WORKSPACE $GITHUB_WORKSPACE/../xs-env
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
+            wget https://github.com/llvm/circt/releases/download/firtool-1.56.1/firrtl-bin-linux-x64.tar.gz
+            tar -xzf firrtl-bin-linux-x64.tar.gz
+            export FIRTOOL_BIN=$(pwd)/firtool-1.56.1/bin/firtool
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make init
+
+      - name: Generate Verilog
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make verilog
+
+      - name: Generate Verilog(MFC=1)
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make verilog MFC=1 FIRTOOL=${FIRTOOL_BIN}
 
       - name: Microbench - Nutshell
         run: |
@@ -61,9 +82,6 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
-            wget https://github.com/llvm/circt/releases/download/firtool-1.56.1/firrtl-bin-linux-x64.tar.gz
-            tar -xzf firrtl-bin-linux-x64.tar.gz
-            export FIRTOOL_BIN=$(pwd)/firtool-1.56.1/bin/firtool
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ $(TOP_V): $(SCALA_FILE)
 	mill -i generator[$(CHISEL_VERSION)].runMain top.$(TOP) $(MILL_ARGS) $(FPGA_ARGS)
 ifeq ($(SPLIT_VERILOG), 1)
 	@mv $(SIM_TOP_V) $(TOP_V)
-	cd $(BUILD_DIR) && bash ../scripts/extract_files.sh $(TOP_V)
+	@cd $(BUILD_DIR) && bash ../scripts/extract_files.sh $(TOP_V)
 endif
 	sed -i -e 's/_\(aw\|ar\|w\|r\|b\)_\(\|bits_\)/_\1/g' $@
 	@git log -n 1 >> .__head__
@@ -75,7 +75,7 @@ $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	mill -i generator[$(CHISEL_VERSION)].test.runMain $(SIMTOP) $(MILL_ARGS)
 	@sed -i 's/$$fatal/xs_assert(`__LINE__)/g' $(SIM_TOP_V)
 ifeq ($(SPLIT_VERILOG), 1)
-	cd $(BUILD_DIR) && bash ../scripts/extract_files.sh $(SIM_TOP_V)
+	@cd $(BUILD_DIR) && bash ../scripts/extract_files.sh $(SIM_TOP_V)
 endif
 
 sim-verilog: $(SIM_TOP_V)

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,16 @@ ifeq ($(MFC), 1)
 CHISEL_VERSION = 6.0.0-M3
 endif
 
+SPLIT_VERILOG = 0
+
 ifneq (,$(filter 3%,$(CHISEL_VERSION)))
 MILL_ARGS += --output-file $(@F)
-FPGA_ARGS += --infer-rw $(FPGATOP) --repl-seq-mem -c:$(FPGATOP):-o:$(@D)/$(@F).conf
-else ifneq ($(FIRTOOL),)
+FPGA_ARGS += --infer-rw $(FPGATOP) --repl-seq-mem -c:$(FPGATOP):-o:$(@D)/$(@F).conf 
+else 
+SPLIT_VERILOG = 1
+endif
+
+ifneq ($(FIRTOOL),)
 MILL_ARGS += --firtool-binary-path $(FIRTOOL)
 endif
 
@@ -41,6 +47,10 @@ help:
 $(TOP_V): $(SCALA_FILE)
 	mkdir -p $(@D)
 	mill -i generator[$(CHISEL_VERSION)].runMain top.$(TOP) $(MILL_ARGS) $(FPGA_ARGS)
+ifeq ($(SPLIT_VERILOG), 1)
+	@mv $(SIM_TOP_V) $(TOP_V)
+	cd $(BUILD_DIR) && bash ../scripts/extract_files.sh $(TOP_V)
+endif
 	sed -i -e 's/_\(aw\|ar\|w\|r\|b\)_\(\|bits_\)/_\1/g' $@
 	@git log -n 1 >> .__head__
 	@git diff >> .__diff__
@@ -64,11 +74,11 @@ $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	mkdir -p $(@D)
 	mill -i generator[$(CHISEL_VERSION)].test.runMain $(SIMTOP) $(MILL_ARGS)
 	@sed -i 's/$$fatal/xs_assert(`__LINE__)/g' $(SIM_TOP_V)
-
-sim-verilog: $(SIM_TOP_V)
-ifneq ($(CHISEL_VERSION), 3.6.0)
+ifeq ($(SPLIT_VERILOG), 1)
 	cd $(BUILD_DIR) && bash ../scripts/extract_files.sh $(SIM_TOP_V)
 endif
+
+sim-verilog: $(SIM_TOP_V)
 
 emu: sim-verilog
 	$(MAKE) -C ./difftest emu WITH_CHISELDB=0 WITH_CONSTANTIN=0


### PR DESCRIPTION
When CHISEL_VERSION=6.x, we cannot specify mill-outputfile. Rename outputfile in `make verilog`, and split-verilog in both `make emu` and `make verilog`.