### PR TITLE
fix(BPU): btbHit is incorrectly invalidated causing the correct PHT result to be invalidated

### DIFF
--- a/src/main/scala/nutcore/frontend/BPU.scala
+++ b/src/main/scala/nutcore/frontend/BPU.scala
@@ -102,7 +102,7 @@ class BPU_ooo extends NutCoreModule {
   // we should latch the input pc for one cycle
   val pcLatch = RegEnable(io.in.pc.bits, io.in.pc.valid)
   val btbHit = Wire(Vec(4, Bool()))
-  (0 to 3).map(i => btbHit(i) := btbRead(i).valid && btbRead(i).tag === btbAddr.getTag(pcLatch) && !flush)
+  (0 to 3).map(i => btbHit(i) := btbRead(i).valid && btbRead(i).tag === btbAddr.getTag(pcLatch) && !flush && RegNext(btb(i).io.r.req.ready, init = false.B))
   // btbHit will ignore pc(2,0). pc(2,0) is used to build brIdx
   val crosslineJump = btbRead(3).crosslineJump && btbHit(3) && !io.brIdx(0) && !io.brIdx(1) && !io.brIdx(2)
   io.crosslineJump := crosslineJump
@@ -317,7 +317,10 @@ class BPU_inorder extends NutCoreModule {
   // since there is one cycle latency to read SyncReadMem,
   // we should latch the input pc for one cycle
   val pcLatch = RegEnable(io.in.pc.bits, io.in.pc.valid)
-  val btbHit = btbRead.valid && btbRead.tag === btbAddr.getTag(pcLatch) && !flush && !(pcLatch(1) && btbRead.brIdx(0))
+  val btbHit = btbRead.valid && btbRead.tag === btbAddr.getTag(pcLatch) && !flush && RegNext(btb.io.r.req.ready, init = false.B) && !(pcLatch(1) && btbRead.brIdx(0))
+  // btb.io.r.req.ready is used to indicate whether BTB SRAM is doing reset (if is true.B, btbRead.valid can be fake)
+  // we don't use btb.io.r.req.fire because of btb.io.r.req.valid only last for 1 cycle, further causes fake BTB miss
+  // See https://github.com/OSCPU/NutShell/pull/147
   // btbHit will ignore pc(1,0). pc(1,0) is used to build brIdx
   // !(pcLatch(1) && btbRead.brIdx(0)) is used to deal with the following case:
   // -------------------------------------------------

--- a/src/main/scala/nutcore/frontend/BPU.scala
+++ b/src/main/scala/nutcore/frontend/BPU.scala
@@ -102,7 +102,7 @@ class BPU_ooo extends NutCoreModule {
   // we should latch the input pc for one cycle
   val pcLatch = RegEnable(io.in.pc.bits, io.in.pc.valid)
   val btbHit = Wire(Vec(4, Bool()))
-  (0 to 3).map(i => btbHit(i) := btbRead(i).valid && btbRead(i).tag === btbAddr.getTag(pcLatch) && !flush && RegNext(btb(i).io.r.req.fire, init = false.B))
+  (0 to 3).map(i => btbHit(i) := btbRead(i).valid && btbRead(i).tag === btbAddr.getTag(pcLatch) && !flush)
   // btbHit will ignore pc(2,0). pc(2,0) is used to build brIdx
   val crosslineJump = btbRead(3).crosslineJump && btbHit(3) && !io.brIdx(0) && !io.brIdx(1) && !io.brIdx(2)
   io.crosslineJump := crosslineJump
@@ -317,7 +317,7 @@ class BPU_inorder extends NutCoreModule {
   // since there is one cycle latency to read SyncReadMem,
   // we should latch the input pc for one cycle
   val pcLatch = RegEnable(io.in.pc.bits, io.in.pc.valid)
-  val btbHit = btbRead.valid && btbRead.tag === btbAddr.getTag(pcLatch) && !flush && RegNext(btb.io.r.req.fire, init = false.B) && !(pcLatch(1) && btbRead.brIdx(0))
+  val btbHit = btbRead.valid && btbRead.tag === btbAddr.getTag(pcLatch) && !flush && !(pcLatch(1) && btbRead.brIdx(0))
   // btbHit will ignore pc(1,0). pc(1,0) is used to build brIdx
   // !(pcLatch(1) && btbRead.brIdx(0)) is used to deal with the following case:
   // -------------------------------------------------


### PR DESCRIPTION
# Behavior
I was trying to implement GShare algorithm on NutShell's BPU(https://github.com/ngc7331/NutShell/commit/bc7cddf891a72cf42e5748c5eff0afabfa95d43c), then I noticed something strange (lines 1, 6 and 7 of the log below).
```
1 [                3005] GHR update spec pc=0080004c7c ghr=77ff->0efff
2 [                3005] valid=1, btbHit=1, btbRead._type === BTBtype.B=1, phtTaken=1
3 [                3006] valid=0, btbHit=0, btbRead._type === BTBtype.B=1, phtTaken=1
4 [                3007] valid=0, btbHit=0, btbRead._type === BTBtype.B=1, phtTaken=1
5 [                3028] predictWrong=1, taken=1, isBranch=1, brIdx(0)=0, predicted at                 3007
6 [                3029] GHR update miss pc=0080004c7c ghr=efff->0efff, predicted at                 3007
7 [                3030] PHT update pc=0080004c7c, ghr=77ff, cnt=2->3
```
1. 3005: PHT gives the prediction 1(=taken) and updates GHR speculatively.
2. 3029: GHR receives an update request from ALU, suggesting that 3007 made an incorrect prediction, but the real branch result is 1(=taken) too.

So I added more logs to the ALU and BPU, giving line 5 and lines 2~4 above, respectively. We can see that:
1. 3005: BTB gives hit, type = BTBtype.B, and PHT gives prediction = taken, so the BPU gives redirect valid = 1. (correct)
2. 3006: Somehow btbHit resets to 0, so the BPU gives valid = 0. **(wrong)**
3. 3007: IFU handshake with imem bus successful, select snpc as fetch address based on BPU output (valid=0). **(wrong)**
4. 3028: ALU detects a branch prediction error, the real result is taken, and issued a redirect request.
5. 3029/3030: BPU updates accroding to the request.

To sum up, the correct PHT result is invalidated and caused the IFU to operate on the wrong fetch path, reducing branch prediction accuracy and IPC.

The correct log should look like:
```
1 [                3005] GHR update spec pc=0080004c7c ghr=77ff->0efff
2 [                3005] valid=1, btbHit=1, btbRead._type === BTBtype.B=1, phtTaken=1
3 [                3006] valid=1, btbHit=1, btbRead._type === BTBtype.B=1, phtTaken=1
4 [                3007] valid=1, btbHit=1, btbRead._type === BTBtype.B=1, phtTaken=1
5 [                3028] predictWrong=0, taken=1, isBranch=1, brIdx(0)=1, predicted at                 3007
// no update is needed
```

The original BPU behaves exactly the same except for the GHR update mechanism, so it's not a bug of my changes on the fork.

# Solution
https://github.com/OSCPU/NutShell/blob/aeb60192474acafb06905fbf2189afcb7f069ff9/src/main/scala/nutcore/frontend/BPU.scala#L311
https://github.com/OSCPU/NutShell/blob/aeb60192474acafb06905fbf2189afcb7f069ff9/src/main/scala/nutcore/frontend/BPU.scala#L320

Notice the `RegNext(btb.io.r.req.fire, init = false.B)` in `btbHit`. It is only valid for one cycle after the request is valid (`io.in.pc.valid = 1`), but the IFU is not guaranteed a successful handshake with the imem in that cycle, causing the problem.

On the other hand, `btbRead.valid` seems to be enough to ensure that `btbHit` is valid.

Therefore, a quick solution is to just delete this `RegNext`.

The modifications are tested using:
- microbench test
- microbench ref
- dhrystone 500000 runs
- coremark 1000 iterations

And the result shows a 2%~14% increase on prediction accuracy and 1.5%~7% increase on IPC over baseline (aeb6019).

![image](https://github.com/OSCPU/NutShell/assets/22112348/49b40bdf-b2b0-4184-ac10-36526df0bce2)

Note: In the above table, the "right" column in the "IPC" row is the actual IPC value and the "acc" column is the ratio to baseline.