### PR TITLE
Fix epc[0] is always 0, rather than being cleared only at the time of use.

### DIFF
--- a/src/main/scala/nutcore/backend/fu/CSR.scala
+++ b/src/main/scala/nutcore/backend/fu/CSR.scala
@@ -661,7 +661,6 @@ class CSR(implicit val p: NutCoreConfig) extends NutCoreModule with HasCSRConst{
 
   ret := isMret || isSret || isUret
   trapTarget := Mux(delegS, stvec, mtvec)(VAddrBits-1, 0)
-  
   retTarget := DontCare
   // TODO redirect target
   // val illegalEret = TODO


### PR DESCRIPTION
This PR addresses the non-compliance of Nutshell's implementation of epc[0] with specification as well as Issue #149. Privilege Specification Section 3.1.14 as so on states:

>  The low bit of mepc (mepc[0]) is always zero.

Explanation: The specification dictates that epc[0] must be 0 during implementation, rather than being simply cleared at the time of use.

