### PR TITLE
Decode NEMU_TRAP with alu.add

### DIFF
--- a/src/main/scala/nutcore/NutCoreTrap.scala
+++ b/src/main/scala/nutcore/NutCoreTrap.scala
@@ -1,17 +1,17 @@
 /**************************************************************************************
 * Copyright (c) 2020 Institute of Computing Technology, CAS
 * Copyright (c) 2020 University of Chinese Academy of Sciences
-* 
-* NutShell is licensed under Mulan PSL v2.
-* You can use this software according to the terms and conditions of the Mulan PSL v2. 
-* You may obtain a copy of Mulan PSL v2 at:
-*             http://license.coscl.org.cn/MulanPSL2 
-* 
-* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER 
-* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR 
-* FIT FOR A PARTICULAR PURPOSE.  
 *
-* See the Mulan PSL v2 for more details.  
+* NutShell is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*             http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR
+* FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
 package nutcore
@@ -26,7 +26,7 @@ object NutCoreTrap extends HasInstrType {
   def StateRunning   = 3.U
 
   def TRAP    = BitPat("b????????????_?????_000_?????_1101011")
-  val table = Array(TRAP -> List(InstrI, FuType.csr, CSROpType.set))
+  val table = Array(TRAP -> List(InstrI, FuType.alu, ALUOpType.add))
 }
 
 class Monitor extends BlackBox {


### PR DESCRIPTION
This change avoids the NEMU_TRAP instructions to modify the architectural states. It is also decoded with I-Type which does not update the register file.