### PR TITLE
ALU: mask off bit[0] for jump target

### DIFF
--- a/src/main/scala/nutcore/backend/fu/ALU.scala
+++ b/src/main/scala/nutcore/backend/fu/ALU.scala
@@ -116,7 +116,7 @@ class ALU(hasBru: Boolean = false) extends NutCoreModule {
   val isBranch = ALUOpType.isBranch(func)
   val isBru = ALUOpType.isBru(func)
   val taken = LookupTree(ALUOpType.getBranchType(func), branchOpTable) ^ ALUOpType.isBranchInvert(func)
-  val target = Mux(isBranch, io.cfIn.pc + io.offset, adderRes)(VAddrBits-1,0)
+  val target = Mux(isBranch, io.cfIn.pc + io.offset, Cat(adderRes(63, 1), false.B))(VAddrBits-1,0)
   val predictWrong = Mux(!taken && isBranch, io.cfIn.brIdx(0), !io.cfIn.brIdx(0) || (io.redirect.target =/= io.cfIn.pnpc))
   val isRVC = (io.cfIn.instr(1,0) =/= "b11".U)
   assert(io.cfIn.instr(1,0) === "b11".U || isRVC || !valid)


### PR DESCRIPTION
According to the RISC-V spec, JALR sets the least-significant bit of the jump target address to zero.

