### PR TITLE
AXI4RAM: remove the synthesizable option

### DIFF
--- a/src/main/scala/device/AXI4RAM.scala
+++ b/src/main/scala/device/AXI4RAM.scala
@@ -38,7 +38,7 @@ class AXI4RAM[T <: AXI4Lite](_type: T = new AXI4, memByte: Int,
   val wen = in.w.fire && inRange(wIdx)
 
   val rdata = if (useBlackBox) {
-    val mem = DifftestMem(memByte, 8, EnableSynthesizableMemory)
+    val mem = DifftestMem(memByte, 8)
     when (wen) {
       mem.write(
         addr = wIdx,

--- a/src/main/scala/nutcore/NutCore.scala
+++ b/src/main/scala/nutcore/NutCore.scala
@@ -43,7 +43,6 @@ trait HasNutCoreParameter {
   val DataBytes = DataBits / 8
   val EnableVirtualMemory = if (Settings.get("HasDTLB") && Settings.get("HasITLB")) true else false
   val EnablePerfCnt = true
-  val EnableSynthesizableMemory = false
   // Parameter for Argo's OoO backend
   val EnableMultiIssue = Settings.get("EnableMultiIssue")
   val EnableOutOfOrderExec = Settings.get("EnableOutOfOrderExec")


### PR DESCRIPTION
Difftest will refactor the DifftestMem implementation and remove this argument. To avoid CI failures, we remove this.