### PR TITLE
NutShellSim: use 2GB AXI4RAM

### DIFF
--- a/src/main/scala/device/AXI4RAM.scala
+++ b/src/main/scala/device/AXI4RAM.scala
@@ -18,19 +18,15 @@ package device
 
 import chisel3._
 import chisel3.util._
-import chisel3.util.experimental.loadMemoryFromFile
 
 import nutcore.HasNutCoreParameter
 import bus.axi4._
-import utils._
 import difftest.common.DifftestMem
 
-class AXI4RAM[T <: AXI4Lite](_type: T = new AXI4, memByte: Int,
+class AXI4RAM[T <: AXI4Lite](_type: T = new AXI4, memByte: Long,
   useBlackBox: Boolean = false) extends AXI4SlaveModule(_type) with HasNutCoreParameter {
 
-  val offsetBits = log2Up(memByte)
-  val offsetMask = (1 << offsetBits) - 1
-  def index(addr: UInt) = (addr & offsetMask.U) >> log2Ceil(DataBytes)
+  def index(addr: UInt) = addr(log2Ceil(memByte) - 1, log2Ceil(DataBytes))
   def inRange(idx: UInt) = idx < (memByte / 8).U
 
   val wIdx = index(waddr) + writeBeatCnt

--- a/src/main/scala/sim/NutShellSim.scala
+++ b/src/main/scala/sim/NutShellSim.scala
@@ -26,7 +26,7 @@ import system._
 class SimTop extends Module {
   lazy val config = NutCoreConfig(FPGAPlatform = false)
   val soc = Module(new NutShell()(config))
-  val mem = Module(new AXI4RAM(memByte = 128 * 1024 * 1024, useBlackBox = true))
+  val mem = Module(new AXI4RAM(memByte = 2L * 1024 * 1024 * 1024, useBlackBox = true))
   // Be careful with the commit checking of emu.
   // A large delay will make emu incorrectly report getting stuck.
   val memdelay = Module(new AXI4Delayer(0))


### PR DESCRIPTION
Use a larger RAM to run modern workloads. We also improve the code quality of index in AXI4RAM.