### PR TITLE
NutShell master branch re-adaption for FPGA platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,15 @@ jobs:
             source ./env.sh
             make clean
             make verilog
-
+      - name: Generate Verilog for FPGA
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make verilog BOARD=pynq
+            
       - name: Microbench - Nutshell
         run: |
             cd $GITHUB_WORKSPACE/../xs-env

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 TOP = TopMain
 SIM_TOP = SimTop
-FPGATOP = NutShellFPGATop
+FPGATOP = Top
+REAL_TOP = $(if $(subst "sim","",$(BOARD)),$(FPGATOP), $(SIM_TOP) )
 
 BUILD_DIR = $(abspath ./build)
 
 RTL_DIR = $(BUILD_DIR)/rtl
 RTL_SUFFIX ?= sv
-SIM_TOP_V = $(RTL_DIR)/$(SIM_TOP).$(RTL_SUFFIX)
+SIM_TOP_V = $(RTL_DIR)/$(REAL_TOP).$(RTL_SUFFIX) # if use FPGA, use FPGATOP
 TOP_V = $(RTL_DIR)/$(TOP).$(RTL_SUFFIX)
 
 SCALA_FILE = $(shell find ./src/main/scala -name '*.scala')

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TOP = TopMain
 SIM_TOP = SimTop
 FPGATOP = Top
-REAL_TOP = $(if $(subst "sim","",$(BOARD)),$(FPGATOP), $(SIM_TOP) )
+REAL_TOP = $(if $(strip $(subst sim,,$(BOARD))),$(FPGATOP),$(SIM_TOP))
 
 BUILD_DIR = $(abspath ./build)
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,9 @@ $(TOP_V): $(SCALA_FILE)
 	mkdir -p $(@D)
 	mill -i generator.test.runMain top.$(TOP) $(MILL_ARGS_ALL) $(FPGA_ARGS)
 	@mv $(SIM_TOP_V) $(TOP_V)
-	sed -i -e 's/_\(aw\|ar\|w\|r\|b\)_\(\|bits_\)/_\1/g' $@
+	@for file in $(RTL_DIR)/*.$(RTL_SUFFIX); do                               \
+		sed -i -e 's/_\(aw\|ar\|w\|r\|b\)_\(\|bits_\)/_\1/g' "$$file";        \
+	done
 	@git log -n 1 >> .__head__
 	@git diff >> .__diff__
 	@sed -i 's/^/\/\// ' .__head__

--- a/fpga/NutShell.tcl
+++ b/fpga/NutShell.tcl
@@ -25,9 +25,7 @@ set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
    puts ""
-   catch {common::send_msg_id "BD_TCL-109" "ERROR" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
-
-   return 1
+   catch {common::send_msg_id "BD_TCL-1002" "WARNING" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
 }
 
 ################################################################

--- a/fpga/board/PXIe/bd/arm.tcl
+++ b/fpga/board/PXIe/bd/arm.tcl
@@ -25,9 +25,7 @@ set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
    puts ""
-   catch {common::send_msg_id "BD_TCL-109" "ERROR" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
-
-   return 1
+   catch {common::send_msg_id "BD_TCL-1002" "WARNING" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
 }
 
 ################################################################

--- a/fpga/board/axu3cg/bd/arm.tcl
+++ b/fpga/board/axu3cg/bd/arm.tcl
@@ -25,9 +25,7 @@ set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
    puts ""
-   catch {common::send_msg_id "BD_TCL-109" "ERROR" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
-
-   return 1
+   catch {common::send_msg_id "BD_TCL-1002" "WARNING" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
 }
 
 ################################################################

--- a/fpga/board/common.tcl
+++ b/fpga/board/common.tcl
@@ -30,6 +30,7 @@ set bd_dir      ${script_dir}/bd
 set constr_dir  ${script_dir}/constr
 set data_dir    ${script_dir}/data
 set ip_dir      ${script_dir}/ip
+set nutshell_build_dir ${fpga_dir}/../build/rtl
 
 create_project $project_name -force -dir $project_dir/ -part ${device}
 if {[info exists board]} {
@@ -44,17 +45,15 @@ add_files -norecurse -fileset sources_1 $inc_files
 set_property is_global_include true [get_files $inc_files]
 
 # Add files for nutshell
-lappend src_files "[file normalize "${fpga_dir}/../build/TopMain.v"]" \
-                  "[file normalize "${fpga_dir}/../build/DifftestRunaheadEvent.v"]" \
-                  "[file normalize "${fpga_dir}/../build/DifftestRunaheadRedirectEvent.v"]"
+set nutshell_rtl [glob -d ${nutshell_build_dir} *.sv or *.v]
+
+foreach src_file ${nutshell_rtl} {
+  lappend src_files [file normalize $src_file]
+}
 
 add_files -norecurse -fileset sources_1 $src_files
-
-# Mark file type of difftest files as SystemVerilog to support DPI statements
-set_property file_type SystemVerilog -objects [get_files -of_objects [get_filesets sources_1] [list \
-  "*/DifftestRunaheadRedirectEvent.v" \
-  "*/DifftestRunaheadEvent.v" \
-]]
+set_property file_type Verilog -objects [get_files -of_objects [get_filesets sources_1] *NutShell.sv] 
+# vivado do not support a system verilog file be the top of a reference design, this may be removed as reference design is not need actually
 
 if {[info exists xdc_files]} {
   add_files -norecurse -fileset constrs_1 $xdc_files

--- a/fpga/board/pynq/bd/standalone.tcl
+++ b/fpga/board/pynq/bd/standalone.tcl
@@ -25,9 +25,7 @@ set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
    puts ""
-   catch {common::send_msg_id "BD_TCL-109" "ERROR" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
-
-   return 1
+   catch {common::send_msg_id "BD_TCL-1002" "WARNING" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
 }
 
 ################################################################

--- a/src/main/scala/nutcore/backend/fu/CSR.scala
+++ b/src/main/scala/nutcore/backend/fu/CSR.scala
@@ -885,7 +885,11 @@ class CSR(implicit val p: NutCoreConfig) extends NutCoreModule with HasCSRConst{
   }}
 
   val nutcoretrap = WireInit(false.B)
-  BoringUtils.addSink(nutcoretrap, "nutcoretrap")
+  if (!p.FPGAPlatform) {
+    BoringUtils.addSink(nutcoretrap, "nutcoretrap")
+  } else {
+    nutcoretrap := 0.U
+  }
   def readWithScala(addr: Int): UInt = mapping(addr)._1
 
   if (!p.FPGAPlatform) {

--- a/src/main/scala/top/Settings.scala
+++ b/src/main/scala/top/Settings.scala
@@ -51,14 +51,16 @@ object PynqSettings {
     "MemMapBase" -> 0x0000000010000000L,
     "MemMapRegionBits" -> 28,
     "MMIOBase" -> 0x00000000e0000000L,
-    "MMIOSize" -> 0x0000000020000000L
+    "MMIOSize" -> 0x0000000020000000L,
+    "EnableDebug" -> false
   )
 }
 
 object Axu3cgSettings {
   def apply() = Map(
     "FPGAPlatform" -> true,
-    "NrExtIntr" -> 2
+    "NrExtIntr" -> 2,
+    "EnableDebug" -> false
   )
 }
 

--- a/src/main/scala/top/Settings.scala
+++ b/src/main/scala/top/Settings.scala
@@ -65,7 +65,8 @@ object Axu3cgSettings {
 object PXIeSettings {
   def apply() = Map(
     "FPGAPlatform" -> true,
-    "NrExtIntr" -> 5
+    "NrExtIntr" -> 5,
+    "EnableDebug" -> false
   )
 }
 

--- a/src/main/scala/utils/Debug.scala
+++ b/src/main/scala/utils/Debug.scala
@@ -42,12 +42,14 @@ object LogUtil {
   def apply(debugLevel: LogLevel)
            (prefix: Boolean, cond: Bool, pable: Printable)
            (implicit name: String): Any = {
-    val c = control()
-    val commonInfo = p"[${c._2}] $name: "
-    when (cond && c._1) {
-      if(prefix) printf(commonInfo)
-      printf(pable)
-    }
+    if (NutCoreConfig().EnableDebug){
+      val c = control()
+      val commonInfo = p"[${c._2}] $name: "
+      when (cond && c._1) {
+        if(prefix) printf(commonInfo)
+        printf(pable)
+      }
+    } 
   }
 }
 


### PR DESCRIPTION
The master branch of NutShell can not generate an FPGA project that provides correct functionality(#205 #204  #200 ). Therefore I made serval changes to the NutShell and the FPGA project tcl. 
1. For software simulation, NutShell uses the `nutcoretrap` in CSR as a signal to dump the statistic during the simulation, this signal is connected by the boringUtil. However, the source of this connection is missing when using the FPGA platform. I set `nutcoretrap` signal to zero when using FPGA.
2. Vivado can automatically identify the signals for AXI protocol if the name of these signals follow a certain form, the early version of NutShell uses a `sed` command in Makefile to convert the Chisel name to the specific form of AXI Signals. However, after using `--spilt-verilog` option, not all the signals were converted by the command. 
3. Still an issue related to the `--spilt-verilog`, vivado project tcl only adds `TopMain.v` to the project, therefore other RTL source files are missing in the vivado project. 
4. The tcl file generated by vivado restricts the version of vivado to 2019.1. However, these restrictions are not needed. I modified the tcl file, currently the mismatch of vivado version will only cause a warning message other than a termination to the project generation.
5. The FPGA platform uses a top name different from the simulation. Current Makefile needs to use `mv` command to rename the top file name from `SimTop.sv` to `TopMain.sv`, which will cause an error to the FPGA platform as the `SimTop.sv`` does not exist.
6. Currently Nutshell uses LogPerfHelper for logging. this module connects all the log units to the control logic in SimTop, which does not exist in the FPGA project. So I have disabled logging for the FPGA platform

The issues mentioned above have been resolved in the pull request. These modifications have been tested with sidewinder and PYNQ.