### PR TITLE
top: enable all layers by default

### DIFF
--- a/src/test/scala/TopMain.scala
+++ b/src/test/scala/TopMain.scala
@@ -92,5 +92,6 @@ object TopMain extends App {
   (new ChiselStage).execute(newArgs, Seq(generator) ++ firtoolOptions
     :+ CIRCTTargetAnnotation(CIRCTTarget.SystemVerilog)
     :+ FirtoolOption("--disable-annotation-unknown")
+    :+ FirtoolOption("--default-layer-specialization=enable")
   )
 }


### PR DESCRIPTION
Chisel v7.0.0 wraps Verification primitives in a verification layer. The generated file should be included by a filelist. To simplify this, we enable all layers by default in NutShell.