### PR TITLE
 fpga_diff: fix FpgaDiffTop generation and renaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 TOP = TopMain
 SIM_TOP = SimTop
-FPGA_DIFF_TOP = FpgaDiffTop
 FPGATOP = Top
 # REAL_TOP selection:
-# - if BOARD is exactly "fpgadiff" -> use FPGA_DIFF_TOP
-# - else if BOARD starts with "sim" -> use SIM_TOP
+# - if BOARD is exactly "fpgadiff" or "sim" -> use SIM_TOP
 # - otherwise use FPGATOP
-REAL_TOP = $(if $(filter fpgadiff,$(BOARD)),$(FPGA_DIFF_TOP),$(if $(filter sim,$(BOARD)),$(SIM_TOP),$(FPGATOP)))
+REAL_TOP = $(if $(filter fpgadiff sim,$(BOARD)),$(SIM_TOP),$(FPGATOP))
 
 BUILD_DIR = $(abspath ./build)
 

--- a/src/test/scala/TopMain.scala
+++ b/src/test/scala/TopMain.scala
@@ -36,12 +36,8 @@ class Top extends Module {
   dontTouch(vga.io)
 }
 
-class FpgaDiffTop extends Module with HasDiffTestInterfaces {
-  lazy val config = NutCoreConfig(FPGADifftest = true)
-  val soc = Module(new NutShell()(config))
-  val io = IO(soc.io.cloneType)
-  soc.io <> io
-
+class FpgaDiffTop extends NutShell()(NutCoreConfig(FPGADifftest = true)) with HasDiffTestInterfaces {
+  override def desiredName: String = "NutShell"
   override def cpuName: Option[String] = Some("NutShell")
   override def connectTopIOs(difftest: DifftestTopIO): Unit = {
     val io = IO(chiselTypeOf(this.io))


### PR DESCRIPTION
This change generates FpgaDiffTop as extend instead of wrapper.

Also, when use `make verilog BOARD=fpgadiff`, the top sv file is
SimTop.sv rather than FpgaDiffTop.sv, this change also revert previous
naming error.