### PR TITLE
Bump difftest: connect AXI inside when !isFPGA

### DIFF
--- a/src/main/scala/sim/NutShellSim.scala
+++ b/src/main/scala/sim/NutShellSim.scala
@@ -36,14 +36,17 @@ class NutShellSim extends Module with HasDiffTestInterfaces {
   soc.io.frontend <> mmio.io.dma
 
   memdelay.io.in <> soc.io.mem
+  mem.io.in <> memdelay.io.out
 
   mmio.io.rw <> soc.io.mmio
 
   soc.io.meip := mmio.io.meip
 
   override def cpuName: Option[String] = Some("NutShell")
-  val memIO = DifftestMemCtrl.exposeIO(memdelay.io.out, mem.io.in)
-  override def difftestMemIO: Option[DifftestMemIO] = Some(memIO)
+  val memIO = Option.when(DifftestModule.isFPGA) {
+    DifftestMemCtrl.exposeIO(memdelay.io.out, mem.io.in)
+  }
+  override def difftestMemIO: Option[DifftestMemIO] = memIO
 
   val uart = IO(new UARTIO)
   uart <> mmio.io.uart


### PR DESCRIPTION
Previous https://github.com/OSCPU/NutShell/pull/258 always expose CPU/MEM AXI ports and connect them in Difftest.
This change move the connect back to DUT inside by default, and only
override `cpu <> mem` with `cpu <> cpuIO` and `mem <> memIO` when
isFPGA with DifftestMemCtrl.exposeIO(cpuAXI,memAXI).