### PR TITLE
sign-extend rs2 for AMOMIN.W/AMOMAX.W operations

### DIFF
--- a/src/main/scala/nutcore/backend/fu/LSU.scala
+++ b/src/main/scala/nutcore/backend/fu/LSU.scala
@@ -178,14 +178,18 @@ class AtomALU extends NutCoreModule {
 
   // src1: load result
   // src2: reg  result
-  val src1 = io.src1
-  val src2 = io.src2
+  // AMO.W compares 32-bit operands.  Normalize both inputs before selecting
+  // MIN/MAX; in particular, rs2 still contains its original 64-bit value.
+  val src1 = Mux(io.isWordOp, SignExt(io.src1(31, 0), XLEN), io.src1)
+  val src2 = Mux(io.isWordOp, SignExt(io.src2(31, 0), XLEN), io.src2)
+  val usrc1 = Mux(io.isWordOp, ZeroExt(io.src1(31, 0), XLEN), io.src1)
+  val usrc2 = Mux(io.isWordOp, ZeroExt(io.src2(31, 0), XLEN), io.src2)
   val func = io.func
   val isAdderSub = !LSUOpType.isAdd(func)
   val adderRes = (src1 +& (src2 ^ Fill(XLEN, isAdderSub))) + isAdderSub
   val xorRes = src1 ^ src2
-  val sltu = !adderRes(XLEN)
-  val slt = xorRes(XLEN-1) ^ sltu
+  val sltu = usrc1 < usrc2
+  val slt = src1.asSInt < src2.asSInt
 
   val res = LookupTreeDefault(func(5, 0), adderRes, List(
     LSUOpType.amoswap -> src2,
@@ -193,10 +197,10 @@ class AtomALU extends NutCoreModule {
     LSUOpType.amoxor  -> xorRes,
     LSUOpType.amoand  -> (src1 & src2),
     LSUOpType.amoor   -> (src1 | src2),
-    LSUOpType.amomin  -> Mux(slt(0), src1, src2),
-    LSUOpType.amomax  -> Mux(slt(0), src2, src1),
-    LSUOpType.amominu -> Mux(sltu(0), src1, src2),
-    LSUOpType.amomaxu -> Mux(sltu(0), src2, src1)
+    LSUOpType.amomin  -> Mux(slt, src1, src2),
+    LSUOpType.amomax  -> Mux(slt, src2, src1),
+    LSUOpType.amominu -> Mux(sltu, usrc1, usrc2),
+    LSUOpType.amomaxu -> Mux(sltu, usrc2, usrc1)
   ))
 
   io.result :=  Mux(io.isWordOp, SignExt(res(31,0), 64), res(XLEN-1,0))


### PR DESCRIPTION
fix(atomalu): sign-extend rs2 for AMOMIN.W/AMOMAX.W operations

## Summary
Fix a hardware bug in AtomALU where rs2 is not properly sign-extended for `.W` atomic operations.

## Background & Changes
In `LSU.scala:181` (AtomALU), the following issues were identified:
- `AMOMIN.W` / `AMOMAX.W`: rs2 was **not sign-extended** from 32-bit to 64-bit
- `AMOMINU.W` / `AMOMAXU.W`: rs2 was **not zero-extended** for unsigned comparison

Example: `0x00000000ffffffff` should be treated as `-1` for `AMOMIN.W`, but the original RTL treated it as a positive 64-bit value (`0xffffffff`).

**Fix applied:**
- Signed word operations (`AMOMIN.W`/`AMOMAX.W`): sign-extend lower 32 bits of rs2
- Unsigned word operations (`AMOMINU.W`/`AMOMAXU.W`): zero-extend lower 32 bits of rs2
- `.D` operations: unchanged (64-bit behavior)

## Test Results
**Before fix:**
`a0 different: right = 0xffffffffffffffff, wrong = 0x0000000000000001`
**After fix:**
`HIT GOOD TRAP at pc = 0x800000d2, exit code = 0`
All 35 existing NutShell cputest images pass DiffTest (`failed=0`).

## Modified Files
- `src/main/scala/nutcore/backend/fu/LSU.scala`: Fix rs2 extension for `.W` AMO operations

## Release Notes
Fix signed/unsigned comparison behavior for AMOMIN.W/AMOMAX.W/AMOMINU.W/AMOMAXU.W operations in AtomALU.

- [x] I have tested these changes locally